### PR TITLE
Parallelization

### DIFF
--- a/crates/core/src/tree/second_order.rs
+++ b/crates/core/src/tree/second_order.rs
@@ -174,7 +174,6 @@ struct PendingSplit {
     start: usize,
     mid: usize,
     end: usize,
-    split: SplitChoice,
     evaluation: StandardNodeEvaluation,
 }
 
@@ -526,9 +525,8 @@ fn train_standard_structure(
                         node_index,
                         depth,
                         start,
-                        mid,
+                        mid: start,
                         end,
-                        split,
                         evaluation,
                     });
                 }
@@ -544,6 +542,14 @@ fn train_standard_structure(
                 }
             }
         }
+
+        pending_splits.sort_unstable_by_key(|pending| pending.start);
+        partition_pending_splits_in_place(
+            context.table,
+            rows,
+            &mut pending_splits,
+            context.parallelism,
+        );
 
         frontier = if context.parallelism.enabled() {
             pending_splits
@@ -793,6 +799,93 @@ fn train_oblivious_structure(
         },
         root_canary_selected,
     )
+}
+
+fn partition_pending_splits_in_place(
+    table: &dyn TableAccess,
+    rows: &mut [usize],
+    pending_splits: &mut [PendingSplit],
+    parallelism: Parallelism,
+) {
+    if pending_splits.is_empty() {
+        return;
+    }
+    partition_pending_splits_recursive(table, rows, pending_splits, 0, parallelism);
+}
+
+fn partition_pending_splits_recursive(
+    table: &dyn TableAccess,
+    rows: &mut [usize],
+    pending_splits: &mut [PendingSplit],
+    base_offset: usize,
+    parallelism: Parallelism,
+) {
+    if pending_splits.is_empty() {
+        return;
+    }
+    if pending_splits.len() == 1 {
+        let pending = &mut pending_splits[0];
+        let local_start = pending.start - base_offset;
+        let local_end = pending.end - base_offset;
+        let split = pending
+            .evaluation
+            .best_split
+            .expect("pending split must retain split choice");
+        let left_count = partition_rows_for_binary_split(
+            table,
+            split.feature_index,
+            split.threshold_bin,
+            MissingBranchDirection::Right,
+            &mut rows[local_start..local_end],
+        );
+        pending.mid = pending.start + left_count;
+        return;
+    }
+
+    let pending_len = pending_splits.len();
+    let mid_index = pending_len / 2;
+    let split_start = pending_splits[mid_index].start;
+    let split_offset = split_start - base_offset;
+    let (left_rows, right_rows) = rows.split_at_mut(split_offset);
+    let (left_pending, right_pending) = pending_splits.split_at_mut(mid_index);
+
+    if parallelism.enabled() && pending_len >= 4 {
+        rayon::join(
+            || {
+                partition_pending_splits_recursive(
+                    table,
+                    left_rows,
+                    left_pending,
+                    base_offset,
+                    parallelism,
+                )
+            },
+            || {
+                partition_pending_splits_recursive(
+                    table,
+                    right_rows,
+                    right_pending,
+                    split_start,
+                    parallelism,
+                )
+            },
+        );
+    } else {
+        partition_pending_splits_recursive(
+            table,
+            left_rows,
+            left_pending,
+            base_offset,
+            parallelism,
+        );
+        partition_pending_splits_recursive(
+            table,
+            right_rows,
+            right_pending,
+            split_start,
+            parallelism,
+        );
+    }
 }
 
 fn evaluate_standard_node(

--- a/crates/core/src/tree/second_order.rs
+++ b/crates/core/src/tree/second_order.rs
@@ -160,6 +160,24 @@ struct ActiveNode {
     histograms: Option<Vec<SecondOrderFeatureHistogram>>,
 }
 
+struct FrontierNodeEvaluation {
+    node_index: usize,
+    depth: usize,
+    start: usize,
+    end: usize,
+    evaluation: StandardNodeEvaluation,
+}
+
+struct PendingSplit {
+    node_index: usize,
+    depth: usize,
+    start: usize,
+    mid: usize,
+    end: usize,
+    split: SplitChoice,
+    evaluation: StandardNodeEvaluation,
+}
+
 #[derive(Debug, Clone)]
 struct SecondOrderHistogramBin {
     count: usize,
@@ -436,31 +454,51 @@ fn train_standard_structure(
     }];
 
     while !frontier.is_empty() {
-        let evaluations = frontier
-            .iter()
-            .map(|active| {
-                (
-                    active.node_index,
-                    active.depth,
-                    active.start,
-                    active.end,
-                    evaluate_standard_node(
+        let evaluations = if context.parallelism.enabled() {
+            frontier
+                .into_par_iter()
+                .map(|active| FrontierNodeEvaluation {
+                    node_index: active.node_index,
+                    depth: active.depth,
+                    start: active.start,
+                    end: active.end,
+                    evaluation: evaluate_standard_node(
                         context,
                         &rows[active.start..active.end],
                         active.depth,
-                        active.histograms.clone(),
+                        active.histograms,
                     ),
-                )
-            })
-            .collect::<Vec<_>>();
-        let mut next_frontier = Vec::new();
+                })
+                .collect::<Vec<_>>()
+        } else {
+            frontier
+                .into_iter()
+                .map(|active| FrontierNodeEvaluation {
+                    node_index: active.node_index,
+                    depth: active.depth,
+                    start: active.start,
+                    end: active.end,
+                    evaluation: evaluate_standard_node(
+                        context,
+                        &rows[active.start..active.end],
+                        active.depth,
+                        active.histograms,
+                    ),
+                })
+                .collect::<Vec<_>>()
+        };
+        let mut pending_splits = Vec::new();
 
-        for (node_index, depth, start, end, evaluation) in evaluations {
+        for FrontierNodeEvaluation {
+            node_index,
+            depth,
+            start,
+            end,
+            evaluation,
+        } in evaluations
+        {
             match evaluation.best_split {
                 Some(split) if split.gain > context.options.min_gain_to_split => {
-                    let histograms = evaluation
-                        .histograms
-                        .expect("splittable second-order node must retain histograms");
                     let left_count = partition_rows_for_binary_split(
                         context.table,
                         split.feature_index,
@@ -469,30 +507,6 @@ fn train_standard_structure(
                         &mut rows[start..end],
                     );
                     let mid = start + left_count;
-
-                    let (left_histograms, right_histograms) = if left_count <= end - mid {
-                        let left_histograms = build_second_order_feature_histograms(
-                            context.table,
-                            context.gradients,
-                            context.hessians,
-                            &rows[start..mid],
-                            context.parallelism,
-                        );
-                        let right_histograms =
-                            subtract_feature_histograms(&histograms, &left_histograms);
-                        (left_histograms, right_histograms)
-                    } else {
-                        let right_histograms = build_second_order_feature_histograms(
-                            context.table,
-                            context.gradients,
-                            context.hessians,
-                            &rows[mid..end],
-                            context.parallelism,
-                        );
-                        let left_histograms =
-                            subtract_feature_histograms(&histograms, &right_histograms);
-                        (left_histograms, right_histograms)
-                    };
 
                     let left_child = push_leaf(nodes, evaluation.leaf_prediction, mid - start);
                     let right_child = push_leaf(nodes, evaluation.leaf_prediction, end - mid);
@@ -508,19 +522,14 @@ fn train_standard_structure(
                         gain: split.gain,
                         variance: None,
                     };
-                    next_frontier.push(ActiveNode {
-                        node_index: left_child,
-                        depth: depth + 1,
+                    pending_splits.push(PendingSplit {
+                        node_index,
+                        depth,
                         start,
-                        end: mid,
-                        histograms: Some(left_histograms),
-                    });
-                    next_frontier.push(ActiveNode {
-                        node_index: right_child,
-                        depth: depth + 1,
-                        start: mid,
+                        mid,
                         end,
-                        histograms: Some(right_histograms),
+                        split,
+                        evaluation,
                     });
                 }
                 _ => {
@@ -536,7 +545,125 @@ fn train_standard_structure(
             }
         }
 
-        frontier = next_frontier;
+        frontier = if context.parallelism.enabled() {
+            pending_splits
+                .into_par_iter()
+                .flat_map_iter(|pending| {
+                    let parent_histograms = pending
+                        .evaluation
+                        .histograms
+                        .expect("splittable second-order node must retain histograms");
+                    let left_len = pending.mid - pending.start;
+                    let right_len = pending.end - pending.mid;
+                    let (left_histograms, right_histograms) = if left_len <= right_len {
+                        let left_histograms = build_second_order_feature_histograms(
+                            context.table,
+                            context.gradients,
+                            context.hessians,
+                            &rows[pending.start..pending.mid],
+                            Parallelism::sequential(),
+                        );
+                        let right_histograms =
+                            subtract_feature_histograms(&parent_histograms, &left_histograms);
+                        (left_histograms, right_histograms)
+                    } else {
+                        let right_histograms = build_second_order_feature_histograms(
+                            context.table,
+                            context.gradients,
+                            context.hessians,
+                            &rows[pending.mid..pending.end],
+                            Parallelism::sequential(),
+                        );
+                        let left_histograms =
+                            subtract_feature_histograms(&parent_histograms, &right_histograms);
+                        (left_histograms, right_histograms)
+                    };
+                    let left_child = match &nodes[pending.node_index] {
+                        RegressionNode::BinarySplit { left_child, .. } => *left_child,
+                        RegressionNode::Leaf { .. } => unreachable!("split node must exist"),
+                    };
+                    let right_child = match &nodes[pending.node_index] {
+                        RegressionNode::BinarySplit { right_child, .. } => *right_child,
+                        RegressionNode::Leaf { .. } => unreachable!("split node must exist"),
+                    };
+                    [
+                        ActiveNode {
+                            node_index: left_child,
+                            depth: pending.depth + 1,
+                            start: pending.start,
+                            end: pending.mid,
+                            histograms: Some(left_histograms),
+                        },
+                        ActiveNode {
+                            node_index: right_child,
+                            depth: pending.depth + 1,
+                            start: pending.mid,
+                            end: pending.end,
+                            histograms: Some(right_histograms),
+                        },
+                    ]
+                })
+                .collect::<Vec<_>>()
+        } else {
+            pending_splits
+                .into_iter()
+                .flat_map(|pending| {
+                    let parent_histograms = pending
+                        .evaluation
+                        .histograms
+                        .expect("splittable second-order node must retain histograms");
+                    let left_len = pending.mid - pending.start;
+                    let right_len = pending.end - pending.mid;
+                    let (left_histograms, right_histograms) = if left_len <= right_len {
+                        let left_histograms = build_second_order_feature_histograms(
+                            context.table,
+                            context.gradients,
+                            context.hessians,
+                            &rows[pending.start..pending.mid],
+                            Parallelism::sequential(),
+                        );
+                        let right_histograms =
+                            subtract_feature_histograms(&parent_histograms, &left_histograms);
+                        (left_histograms, right_histograms)
+                    } else {
+                        let right_histograms = build_second_order_feature_histograms(
+                            context.table,
+                            context.gradients,
+                            context.hessians,
+                            &rows[pending.mid..pending.end],
+                            Parallelism::sequential(),
+                        );
+                        let left_histograms =
+                            subtract_feature_histograms(&parent_histograms, &right_histograms);
+                        (left_histograms, right_histograms)
+                    };
+                    let left_child = match &nodes[pending.node_index] {
+                        RegressionNode::BinarySplit { left_child, .. } => *left_child,
+                        RegressionNode::Leaf { .. } => unreachable!("split node must exist"),
+                    };
+                    let right_child = match &nodes[pending.node_index] {
+                        RegressionNode::BinarySplit { right_child, .. } => *right_child,
+                        RegressionNode::Leaf { .. } => unreachable!("split node must exist"),
+                    };
+                    [
+                        ActiveNode {
+                            node_index: left_child,
+                            depth: pending.depth + 1,
+                            start: pending.start,
+                            end: pending.mid,
+                            histograms: Some(left_histograms),
+                        },
+                        ActiveNode {
+                            node_index: right_child,
+                            depth: pending.depth + 1,
+                            start: pending.mid,
+                            end: pending.end,
+                            histograms: Some(right_histograms),
+                        },
+                    ]
+                })
+                .collect::<Vec<_>>()
+        };
     }
 
     root

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -57,15 +57,23 @@ Some groundwork for that plan is now in place:
 - standard second-order CART/randomized trees now use an active-node frontier,
   so a whole depth is evaluated before any node at that depth partitions the
   shared row-index buffer
+- same-depth frontier evaluation now runs in parallel, so standard
+  second-order trees already batch node work at one depth
+- child histogram construction for the next frontier now also runs in parallel
+  across the nodes that split at the current depth
 - second-order histogram construction now has a parallel-capable shared helper
   instead of forcing the GBM path through a purely sequential per-feature build
 
 That changes the next concrete implementation step. The structural batching
-boundary now exists, so the next work should focus on using it:
+boundary now exists and is partially exercised, so the next work should focus
+on pushing it further:
 
-- parallelize histogram construction across batches of active nodes
-- parallelize split scoring across features within those node batches
-- keep row partitioning as the later mutation step after split selection
+- reduce overhead in the frontier batch path so same-depth parallelism scales
+  better on larger trees
+- parallelize row partitioning once the mutation phase is proven stable enough
+  to benefit
+- add more aggressive SIMD work in histogram accumulation and reduction hot
+  paths
 
 ## Random-forest training on wide data
 

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -59,6 +59,8 @@ Some groundwork for that plan is now in place:
   shared row-index buffer
 - same-depth frontier evaluation now runs in parallel, so standard
   second-order trees already batch node work at one depth
+- same-depth row partitioning now also runs in parallel across disjoint
+  row-buffer slices after split choices have been fixed
 - child histogram construction for the next frontier now also runs in parallel
   across the nodes that split at the current depth
 - second-order histogram construction now has a parallel-capable shared helper
@@ -70,10 +72,10 @@ on pushing it further:
 
 - reduce overhead in the frontier batch path so same-depth parallelism scales
   better on larger trees
-- parallelize row partitioning once the mutation phase is proven stable enough
-  to benefit
 - add more aggressive SIMD work in histogram accumulation and reduction hot
   paths
+- profile whether frontier-level work scheduling should become more adaptive on
+  small trees where synchronization overhead can outweigh gains
 
 ## Random-forest training on wide data
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -323,7 +323,8 @@ The standard second-order path now uses that boundary in three explicit phases
 for each depth:
 
 1. evaluate the current frontier in parallel
-2. partition row ranges for the nodes that actually split
+2. partition row ranges for the nodes that actually split in parallel across
+   disjoint row-buffer slices
 3. build child histograms for the next frontier in parallel
 
 That means the frontier is no longer only a structural preparation for future
@@ -361,6 +362,12 @@ When training parallelism is enabled, that evaluation phase runs across the
 whole active frontier at once. Each node still scores its own candidate
 features using the same histogram-based split logic as before, but same-depth
 nodes can now do that work concurrently.
+
+The later mutation phase is now parallel too. Pending same-depth splits are
+sorted by their owned row ranges, then partitioned through a recursive
+divide-and-conquer pass over disjoint slices of the shared row-index buffer.
+That keeps the in-place row-buffer model intact while allowing non-overlapping
+partitions to run concurrently.
 
 ### Histograms and child reuse
 
@@ -412,6 +419,8 @@ view of the current row ownership. That makes several future steps much cleaner:
 
 - scoring active nodes in parallel
 - feature-parallel split search inside each node evaluation
+- partitioning disjoint same-depth row ranges in parallel once split choices
+  are known
 - building child histograms across splitting nodes in parallel after
   partitioning
 - postponing row partitioning until after split selection is complete
@@ -457,8 +466,8 @@ ForestFire training is optimized around a compact binned core and shared row-ind
 - random forests parallelize across trees while limiting intra-tree parallelism
 - standard second-order CART/randomized trees now grow through a level-wise
   active-node frontier, with parallel frontier evaluation, feature-parallel
-  split scoring, and parallel child-histogram construction separated from the
-  later row-buffer mutation step
+  split scoring, parallel row partitioning over disjoint slices, and parallel
+  child-histogram construction separated by explicit frontier phases
 - binary sparse inputs stay sparse through training and inference
 - classifier, regressor, and second-order tree builders now share the same core
   histogram/partitioning/randomization helpers instead of carrying separate

--- a/docs/training.md
+++ b/docs/training.md
@@ -319,6 +319,17 @@ That separation is the architectural point of the frontier:
   occupy contiguous ranges"
 - child creation is "record those new ranges as the next active frontier"
 
+The standard second-order path now uses that boundary in three explicit phases
+for each depth:
+
+1. evaluate the current frontier in parallel
+2. partition row ranges for the nodes that actually split
+3. build child histograms for the next frontier in parallel
+
+That means the frontier is no longer only a structural preparation for future
+parallelism. It is now the execution model used by the standard second-order
+builder.
+
 ### What is evaluated for each active node
 
 For every active node, the builder computes:
@@ -346,6 +357,11 @@ the next frontier.
 If it does split, the builder retains enough information to mutate the row
 buffer afterward without rescoring the node.
 
+When training parallelism is enabled, that evaluation phase runs across the
+whole active frontier at once. Each node still scores its own candidate
+features using the same histogram-based split logic as before, but same-depth
+nodes can now do that work concurrently.
+
 ### Histograms and child reuse
 
 The second-order tree path is histogram-based.
@@ -370,10 +386,15 @@ That matters because histogram construction is one of the dominant training
 costs. Reusing the parent histogram avoids paying that full cost twice per
 split.
 
+That reuse now happens inside the frontier pipeline as well. After partitioning
+has produced the child row ranges for every winning split at the current depth,
+the builder constructs the next frontier’s histograms in parallel across those
+splitting nodes.
+
 ### Why the frontier matters for parallelism
 
-The frontier does not by itself make the whole tree fit fully parallel, but it
-creates the right execution boundary for that work.
+The frontier now provides both the execution boundary and part of the actual
+parallel work for standard second-order trees.
 
 Without a frontier, same-depth siblings are entangled with mutation order:
 
@@ -390,8 +411,9 @@ With a frontier, every node at a depth is evaluated against the same stable
 view of the current row ownership. That makes several future steps much cleaner:
 
 - scoring active nodes in parallel
-- building histograms across active nodes in batches
-- running feature-parallel split search across those node batches
+- feature-parallel split search inside each node evaluation
+- building child histograms across splitting nodes in parallel after
+  partitioning
 - postponing row partitioning until after split selection is complete
 
 The stage loop of gradient boosting still remains serial. The frontier only
@@ -434,8 +456,9 @@ ForestFire training is optimized around a compact binned core and shared row-ind
 - oblivious split scoring reuses cached per-leaf counts or `sum`/`sum_sq`
 - random forests parallelize across trees while limiting intra-tree parallelism
 - standard second-order CART/randomized trees now grow through a level-wise
-  active-node frontier, so one depth can be evaluated before any node at that
-  depth mutates the shared row-index buffer
+  active-node frontier, with parallel frontier evaluation, feature-parallel
+  split scoring, and parallel child-histogram construction separated from the
+  later row-buffer mutation step
 - binary sparse inputs stay sparse through training and inference
 - classifier, regressor, and second-order tree builders now share the same core
   histogram/partitioning/randomization helpers instead of carrying separate


### PR DESCRIPTION
# Summary

This PR upgrades the standard second-order GBM tree builder into a level-wise parallel execution pipeline for CART/randomized trees.

The standard second-order path now grows trees by active frontier rather than immediate depth-first recursion. Same-depth nodes are evaluated as a batch, row partitioning is deferred until split decisions are known, and child histograms for the next frontier are then constructed from the resulting row ranges. The boosting stage loop remains serial, but the work inside one stage’s tree fit is now parallelized across all three major frontier phases.

Concretely, the change now includes:
- a level-wise active-node frontier for standard second-order trees
- parallel frontier evaluation across same-depth active nodes
- feature-parallel split scoring inside node evaluation
- parallel row partitioning across disjoint same-depth row-buffer ranges
- parallel child-histogram construction for the next frontier
- continued histogram reuse by rebuilding only the smaller child directly and deriving the sibling histogram by subtraction from the parent

This keeps the existing split semantics, canary behavior, and shared row-index-buffer model intact while moving the implementation much closer to the intended GBM parallelism architecture.

# Why

Gradient boosting cannot use the same outer parallelism strategy as random forests because each stage depends on the current ensemble state. The practical path is to keep the stage loop serial while making one second-order tree fit more parallel internally.

This PR does that in a staged but real way:
- same-depth nodes can now be processed concurrently
- mutation is isolated into an explicit later phase
- row partitioning can now run concurrently when node ranges do not overlap
- histogram reuse remains intact so the added batching does not throw away previous optimization work

# Implementation

The standard second-order tree path now runs each depth in three phases:

1. Evaluate the current frontier.
   Same-depth active nodes are scored together, and each node still uses the existing histogram-based feature-parallel split search.

2. Partition row ranges for the winning splits.
   This no longer happens inline during recursive descent. Instead, pending splits are partitioned later over disjoint row-buffer slices, and that mutation phase can now run in parallel via recursive range splitting.

3. Build the next frontier.
   Child histograms are constructed in parallel across the nodes that split, while sibling histograms continue to be derived by subtraction from the parent whenever possible.

This preserves the single shared mutable row-index buffer, but makes the mutation boundary explicit and schedulable.

# Documentation

The docs were updated to explain the new execution model in detail.

- [docs/training.md](forest-fire/docs/training.md) now documents:
  - how second-order tree fitting works inside one boosting stage
  - what the active-node frontier is
  - the three-phase frontier pipeline
  - histogram reuse across child nodes
  - why the frontier matters for GBM parallelism
- [docs/next-steps.md](forest-fire/docs/next-steps.md) now treats frontier evaluation, parallel child-histogram build, and parallel row partitioning as completed groundwork and shifts the roadmap toward scaling improvements and more aggressive histogram-hot-path optimization

# Testing

- `cargo test second_order_tree --lib`

# Notes

This PR pushes the current architecture close to the practical limit without a deeper histogram-kernel rewrite. The main remaining optimization space is reducing overhead in the frontier batch path and introducing more aggressive SIMD-oriented histogram accumulation and reduction.