### PR TITLE
add oblique split documentation and update categorical next-steps

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -242,6 +242,121 @@ What this example shows:
 - if the allowed window contains only canaries, the usual canary stop still
   happens
 
+## Example 4: Oblique splits on a rotated boundary
+
+This example shows oblique splits on a dataset whose decision boundary is
+diagonal in feature space. It compares axis-aligned and oblique trees and then
+walks through the same serialize-and-reload lifecycle.
+
+```python
+import numpy as np
+
+from forestfire import Model, train
+
+rng = np.random.default_rng(7)
+n = 15_000
+
+# The true rule is a rotated boundary: x_0 + x_1 > 0.5
+# An axis-aligned tree must approximate this with many staircase splits.
+# An oblique tree can express it in a single node.
+X = rng.normal(size=(n, 8))
+y = (X[:, 0] + X[:, 1] > 0.5).astype(float)
+
+# Axis-aligned baseline
+model_aa = train(
+    X,
+    y,
+    algorithm="dt",
+    tree_type="cart",
+    task="classification",
+    canaries=2,
+)
+
+# Oblique: learns a pairwise linear split w1 * x_i + w2 * x_j <= t
+model_ob = train(
+    X,
+    y,
+    algorithm="dt",
+    tree_type="cart",
+    task="classification",
+    split_strategy="oblique",
+    canaries=2,
+)
+
+print("axis-aligned tree:")
+print(model_aa.tree_structure())
+
+print("oblique tree:")
+print(model_ob.tree_structure())
+
+# Oblique splits are available for random forests and gradient boosting too
+model_rf_ob = train(
+    X,
+    y,
+    algorithm="rf",
+    tree_type="cart",
+    task="classification",
+    split_strategy="oblique",
+    n_trees=300,
+    max_features="sqrt",
+    min_samples_leaf=5,
+)
+
+model_gbm_ob = train(
+    X,
+    y,
+    algorithm="gbm",
+    tree_type="cart",
+    task="classification",
+    split_strategy="oblique",
+    learning_rate=0.05,
+    n_trees=500,
+    canaries=2,
+    filter=0.95,
+)
+
+# All four models follow the same serialize-reload-score lifecycle
+batch = X[:5_000]
+
+for label, model in [
+    ("axis-aligned DT", model_aa),
+    ("oblique DT", model_ob),
+    ("oblique RF", model_rf_ob),
+    ("oblique GBM", model_gbm_ob),
+]:
+    optimized = model.optimize_inference()
+    pred = optimized.predict_proba(batch)
+
+    payload = model.serialize()
+    reloaded = Model.deserialize(payload)
+    reloaded_pred = reloaded.predict_proba(batch)
+
+    print(f"{label}: parity={np.allclose(pred, reloaded_pred)}, used_features={model.used_feature_count}")
+
+# Oblique node structure is visible in introspection
+print(model_ob.tree_node(node_id=0, tree_index=0))
+
+# The IR records the participating feature indices, weights, threshold,
+# and per-feature missing-direction metadata for each oblique node
+ir = model_ob.to_ir_json()
+print(ir[:300])
+```
+
+What this example shows:
+
+- `split_strategy="oblique"` is a drop-in swap that does not change the rest
+  of the API
+- axis-aligned and oblique candidates compete in the same pool at every node,
+  so the oblique model only introduces oblique nodes where they actually win
+- the same optimized inference, serialization, and reload workflow applies to
+  oblique models without any special handling
+- oblique splits are visible in `tree_node(...)` and the JSON IR as
+  `ObliqueLinearCombination` entries with two feature indices, two weights, and
+  a threshold in the projected 1D space
+- `used_feature_count` may differ between axis-aligned and oblique models
+  because oblique nodes can cover two features in one split, and the winning
+  competition may leave different features unused
+
 ## Why these examples matter
 
 ForestFire is not only a trainer and not only an inference runtime.

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ ForestFire is intentionally opinionated in a few places:
 - [Examples](examples.md): end-to-end workflows from training through reload and batch scoring
 - [Training](training.md): algorithms, parameters, and stopping behavior
 - [Categorical Strategies](categorical-strategies.md): `dummy`, `target`, and `fisher` categorical handling through the native training API
+- [Oblique Splits](oblique-splits.md): pairwise linear splits, weight computation, candidate competition, and when to use them
 - [Models And Introspection](models.md): prediction, optimization, serialization, and tree inspection
 - [Benchmarks](benchmarks.md): benchmark tasks and artifact locations
 - [Next Steps](next-steps.md): forward-looking implementation and optimization notes

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -598,89 +598,37 @@ useful breakdown to collect on wide RF workloads is:
 The likely root issue is not lack of outer parallelism. It is that per-node
 per-feature work is still too expensive once the width of the table grows.
 
-## Add categorical-feature support for CART, random forests, and boosting
+## Extend categorical-feature support
 
-Categorical support is one of the clearest remaining training and model-format
-gaps.
+ForestFire now implements three transform-based categorical strategies through
+the unified `train(...)` interface: `dummy`, `target`, and `fisher`. Those
+strategies are documented on the [Categorical Strategies](categorical-strategies.md)
+page.
 
-ForestFire already has explicit numeric and binary preprocessing, and IR v1
-still states that categorical encodings are not implemented. That means this is
-not just a trainer tweak. It touches:
+The current implementation uses explicit table-layer transforms rather than
+native categorical split predicates. That is a practical tradeoff:
 
-- training-time feature representation
-- split-search semantics
-- missing and unknown-category handling
-- optimized runtime execution
-- IR/export metadata
-- Python and Rust API contracts
+- it makes categorical support available through the existing numeric and binary
+  split machinery
+- but it means the learned trees operate on transformed feature space rather
+  than on native category-membership tests
 
-It is also important to separate this roadmap from the existing `id3` / `c45`
-story. Those tree families already allow multiway branching over
-"categorical-like" binned features. The harder unsolved problem is categorical
-support for the CART-style binary-split learners that also underpin random
-forests and gradient boosting.
+The remaining forward-looking work in this area is:
 
-There is no single universally correct categorical strategy. In practice, tree
-systems use several different ones depending on:
+### Native categorical subset splits
 
-- whether the feature is nominal or truly ordered
-- how many distinct categories it has
-- whether the learner is a single tree, a forest, or a stage-wise boosted model
-- whether the implementation has native categorical split search
+The transform-based strategies do not support grouped category tests like:
 
-The main strategies worth supporting or documenting are:
+```text
+x in {"red", "green"} -> left
+x in {"blue"} -> right
+```
 
-### 1. Native categorical subset splits
+A single node can express that rule natively. The transform-based strategies
+approximate it with either multiple binary columns (`dummy`) or a one-dimensional
+ordered surrogate (`target`, `fisher`).
 
-This is the most direct semantic match for CART-style trees.
-
-For a nominal feature with `k` categories, the natural binary split is not a
-numeric threshold like `x <= t`. It is a set-membership test:
-
-- go left if `x in S`
-- go right if `x not in S`
-
-where `S` is some subset of the observed categories.
-
-That matters because nominal categories do not have a meaningful numeric order.
-If a feature contains `{"red", "blue", "green"}`, the useful question is often
-"should `red` and `green` be grouped together against `blue`?" rather than
-"is the encoded integer less than `1.5`?"
-
-For plain CART and random forests, this native subset-split view is the clean
-ideal because it preserves the true hypothesis class:
-
-- one node can isolate a useful grouping of categories directly
-- there is no fake distance notion between category ids
-- the resulting tree structure matches how users think about categorical rules
-
-The difficulty is split-search cost. A `k`-level categorical feature has
-`2^(k-1) - 1` distinct binary partitions if complements are treated as the same
-split. That is manageable for very small `k`, but it becomes too expensive to
-search exhaustively once cardinality grows.
-
-That means a serious implementation needs more than just a categorical column
-type:
-
-- exact subset search for very low-cardinality features
-- heuristics or restricted search once cardinality becomes moderate
-- minimum-support rules so tiny categories do not generate unstable splits
-- a clear policy for categories never seen during training
-
-For gradient boosting, native categorical support usually becomes
-histogram-based rather than exhaustive. The common pattern is:
-
-1. aggregate per-category gradient/Hessian statistics
-2. order categories by some target-like summary derived from those statistics
-3. scan only contiguous partitions in that ordered list instead of all possible
-   subsets
-
-That is the core idea behind the efficient categorical handling used by systems
-like LightGBM and XGBoost. The important point is that the learner still
-produces a native categorical split semantically, even though the search is
-implemented through an ordering trick that avoids the full combinatorial search.
-
-For ForestFire specifically, native categorical subset splits would require:
+Native subset split support for CART-style learners would require:
 
 - a first-class categorical feature representation in the training table
 - per-node category histograms instead of only numeric-bin histograms
@@ -689,258 +637,31 @@ For ForestFire specifically, native categorical subset splits would require:
 - runtime support for fast category-membership tests
 - IR support for categorical split predicates and category vocabularies
 
-This is likely the strongest long-term end state for medium-cardinality
-categoricals because it gives CART, random forests, and GBM a natural and
-expressive treatment without inflating feature width.
-
-### 2. One-hot encoding
-
-One-hot encoding is the lowest-risk compatibility path when native categorical
-split search does not exist yet.
-
-A categorical feature with levels such as `{"red", "blue", "green"}` is
-expanded into multiple binary indicators:
-
-- `is_red`
-- `is_blue`
-- `is_green`
-
-or sometimes `k - 1` indicators plus an implicit baseline level.
-
-The main reason this is attractive for ForestFire is that the system already
-has explicit binary-feature handling. That means one-hot support could reuse a
-large amount of the existing training and runtime machinery:
-
-- binary features already fit the current split model naturally
-- histogram and partitioning logic for binary columns already exists
-- IR support for booleans is already much closer to complete than IR support for
-  categorical predicates
-
-This makes one-hot encoding the easiest near-term path for low-cardinality
-categoricals.
-
-The costs are equally important:
-
-- feature width grows linearly with the number of categories
-- training cost grows because more columns now compete at each node
-- `max_features` semantics become less intuitive because one original feature
-  may explode into many derived binary columns
-- a grouped category rule may now require several tree levels instead of one
-  native split
-
-That last point is easy to underestimate. Suppose the useful rule is
-"`red` or `green` means left, `blue` means right." A native categorical split
-can represent that in one node. A one-hot representation often needs multiple
-binary decisions across different nodes to express the same logic.
-
-This is why one-hot encoding is usually best viewed as a pragmatic baseline, not
-the ideal long-term representation.
-
-The implementation details also matter:
-
-- low-cardinality features should probably be the only automatic one-hot
-  candidates
-- missing and unseen categories should not silently collapse into ordinary
-  all-zero rows unless that behavior is documented as intentional
-- the model contract should record the category vocabulary and expansion mapping
-  if the encoding happens inside training rather than outside the library
-
-One-hot is therefore attractive as a staged first step:
-
-- it gives users a correct nominal treatment for small category sets
-- it leverages the current binary infrastructure
-- it avoids blocking all categorical support on a larger native-split rewrite
-
-### 3. Ordinal or integer encoding
-
-Integer-coded categories are useful, but only under very specific semantics.
-
-There are two very different situations that are often mistakenly grouped
-together:
-
-- truly ordered categories, such as `{"small", "medium", "large"}`
-- arbitrary category ids, such as `{"red", "blue", "green"}` encoded as
-  `{0, 1, 2}`
-
-For genuinely ordered categories, ordinal encoding is reasonable. A split like
-"`size <= medium`" carries real meaning. In that case, a threshold-based CART
-learner is using a true order already present in the data.
-
-For arbitrary nominal categories, plain ordinal encoding is dangerous. A CART
-split over integer ids imposes a fake geometry:
-
-- category `2` is treated as "greater than" category `1`
-- categories with adjacent ids are treated as more similar than distant ids
-- threshold search is forced to cut the categories into contiguous numeric
-  blocks, even though the useful grouping may be non-contiguous in id space
-
-That means a naïve `OrdinalEncoder` plus ordinary CART thresholding is usually
-the wrong thing for nominal features.
-
-The subtle but important exception is native categorical implementations that
-store categories as integers internally while still treating them as labels
-semantically. LightGBM, XGBoost, and similar systems often expect category ids
-to be integer-coded in memory, but that does not mean they are doing ordinary
-numeric thresholding over those ids. The integer code is only a compact storage
-format for a categorical learner.
-
-That distinction is important for ForestFire:
-
-- integer coding may be the right internal representation for category values
-- it should not automatically imply threshold-based numeric split search
-- user-visible APIs should only allow pure ordinal treatment when the feature is
-  explicitly declared ordered
-
-In practice, ordinal encoding should probably appear in the roadmap in only two
-forms:
-
-- as an explicit feature type for genuinely ordered categories
-- as an internal storage detail for native categorical split search
-
-It should not be the default fallback for arbitrary string or enum-like
-features, because that would silently give incorrect semantics while appearing
-to "support categoricals."
-
-### 4. Target, mean, and CTR-style encodings
-
-Target-based encodings are often the strongest preprocessing option for
-high-cardinality categoricals when native subset-split search is unavailable or
-too expensive.
-
-The idea is to replace each category with a target-derived statistic:
-
-- for regression, a smoothed category mean
-- for binary classification, a smoothed positive-class rate or log-odds
-- for multiclass tasks, per-class or otherwise structured target statistics
-
-This turns a high-cardinality categorical feature into one or a few numeric
-features that the existing CART machinery can consume directly.
-
-Why this works well:
-
-- the representation size no longer grows with cardinality the way one-hot does
-- rare categories can borrow strength from the global target prior through
-  smoothing
-- the learner can often extract strong signal from one numeric statistic rather
-  than many sparse indicators
-
-Why it is risky:
-
-- naïve target encoding leaks label information badly
-- the same category may appear in both the statistic and the row being encoded
-- leakage is especially harmful in boosting, where residual fitting is already
-  sensitive to weak accidental signal
-
-So a credible implementation cannot be "compute category means on the full
-training set and call it done."
-
-It needs one of the standard leakage controls:
-
-- out-of-fold or cross-fitted target statistics
-- ordered or prefix-style statistics of the kind popularized by CatBoost
-- strong smoothing and minimum-frequency rules
-- a global-prior fallback for unseen or extremely rare categories
-
-The CatBoost lesson is especially important. Its categorical handling is not
-just "target encoding plus boosting." The key idea is that the statistics are
-computed in an order-aware way so each row is encoded only from earlier rows,
-which sharply reduces target leakage compared with full-dataset means.
-
-For ForestFire, target-style encodings would be attractive for very
-high-cardinality features because they fit the current numeric histogram stack
-much more naturally than full subset-split search. But they come with model
-contract implications:
-
-- the encoding recipe becomes part of preprocessing semantics
-- exported IR must record the prior, smoothing, category statistics, and
-  unknown-category fallback
-- training/test parity depends on preserving exactly how those encodings were
-  produced
-
-This means target encodings are not just an optional preprocessing helper if
-they live inside the library. They become part of the learned model semantics.
-
-### Strategy-specific fit by model family
-
-The strategies above are not equally attractive for every tree family.
-
-For one standalone CART tree:
-
-- native subset splits are the cleanest nominal treatment
-- one-hot is acceptable for low-cardinality features
-- target encoding can help on very high-cardinality data
-- naïve ordinal encoding should be limited to truly ordered features
-
-For random forests:
-
-- the same categorical choices apply at the tree level
-- but high-cardinality features need extra caution because they offer many more
-  candidate splits and can be over-selected
-- one-hot can also distort `max_features` behavior by letting one source feature
-  dominate the sampled candidate pool after expansion
-
-For gradient boosting:
-
-- native histogram-based categorical search is usually the best medium-card
-  solution
-- target or CTR-style encodings are often the strongest high-card solution
-- leakage control matters much more because stage-wise fitting will exploit even
-  weak spurious signal
-- plain one-hot can still work for low-cardinality features, but it is often
-  less elegant and less efficient than native support
-
-### A caution that applies regardless of strategy
-
-Categorical support is not only about feature representation. It also changes
-the statistical behavior of split search.
-
-High-cardinality features are often favored simply because they create more
-candidate partitions. That can lead to:
-
-- overly optimistic impurity gains
-- unstable deep-tree behavior on rare categories
-- biased feature-importance conclusions
-
-That means any serious categorical roadmap should include guardrails such as:
-
-- minimum category frequency thresholds
-- smoothing or shrinkage for target-style encodings
-- possibly restricted subset search for medium/high-cardinality features
-- benchmarks that specifically vary category cardinality and rare-level
-  frequency
-
-This is especially important for random forests, where split-frequency-based
-importance can become misleading when a high-cardinality feature wins often for
-purely combinatorial reasons.
-
-### The most practical staged plan
-
-The cleanest roadmap is probably not "pick one categorical strategy forever."
-It is to support different strategies for different parts of the problem.
-
-The most practical order is:
-
-1. add low-cardinality one-hot support as a compatibility layer that reuses the
-   current binary-feature pipeline
-2. add explicit ordered-category support so truly ordinal features can use
-   threshold splits honestly
-3. add native categorical subset splits for CART and random forests, with exact
-   search only for very low cardinalities and restricted search beyond that
-4. add histogram-based native categorical split search for the second-order GBM
-   path
-5. add leakage-controlled target / CTR encodings for very high-cardinality
-   features
-6. extend IR, optimized runtime, and tests so categorical semantics survive
-   export, reload, and inference parity checks
-
-That staged plan matches the real shape of the problem:
-
-- one-hot is the easiest short-term unlock
-- native subset splits are the best semantic end state for many categorical
-  features
-- target-style encodings are still necessary once cardinality gets large enough
-  that direct subset search becomes awkward or statistically brittle
-
+That is likely the strongest long-term end state for medium-cardinality
+categoricals, but it is a larger architectural change than the transform-based
+strategies.
+
+### Leakage controls for target-style strategies
+
+The current `target` and `fisher` strategies use smoothed training-set
+statistics. That is a practical first implementation, but it does not fully
+prevent target leakage.
+
+A more rigorous approach would use out-of-fold or CatBoost-style prefix
+statistics, so each row is encoded only from earlier rows rather than from the
+full training set. That matters most for gradient boosting, where stage-wise
+residual fitting is especially sensitive to weak spurious signal.
+
+### Canary-informed smoothing
+
+Canaries currently influence encoding strength for `target` and `fisher` by
+increasing effective smoothing when shuffled-category signal looks too
+competitive. See [Canary Strategy: Categorical variables](canaries.md#categorical-variables)
+for how that works.
+
+That mechanism is still heuristic. Stronger and more principled shrinkage rules,
+especially for rare categories and high-cardinality columns in a boosting
+setting, remain open work.
 ## Document semantic edge-case invariants
 
 There are several API and semantics choices that appear intentional but are

--- a/docs/oblique-splits.md
+++ b/docs/oblique-splits.md
@@ -1,0 +1,300 @@
+# Oblique Splits
+
+ForestFire supports two split families: axis-aligned and oblique.
+
+An axis-aligned split tests one feature against one threshold:
+
+```text
+x_i <= t
+```
+
+An oblique split tests a linear combination of two features:
+
+```text
+w1 * x_i + w2 * x_j <= t
+```
+
+That is the entire structural difference. The rest of the training pipeline, canaries, missing-value routing, candidate ranking, and ensemble integration, stays the same.
+
+## Why oblique splits exist
+
+Axis-aligned splits can only draw boundaries parallel to the feature axes.
+
+That is a strong constraint. Many real-world patterns produce decision surfaces that are rotated or diagonal in feature space.
+
+Consider a dataset where the true rule is:
+
+```text
+x_0 + x_1 > 0
+```
+
+An axis-aligned tree cannot express that boundary in a single node. It must approximate it with a staircase of many axis-aligned cuts: first one threshold on `x_0`, then one on `x_1`, then deeper cuts to refine the step pattern.
+
+A single oblique node can capture the same boundary directly:
+
+```text
+1.0 * x_0 + 1.0 * x_1 <= 0
+```
+
+In those settings, oblique splits produce shallower, more expressive trees. The same tree depth covers more of the true function structure.
+
+## How weights are computed
+
+The weights `w1` and `w2` are learned from the training rows that reach the node. They are not user-supplied or randomly initialized.
+
+ForestFire uses different approaches depending on the task.
+
+### Classification
+
+For a given feature pair `(x_i, x_j)`, ForestFire looks for the direction in that 2D feature subspace that best separates the observed classes.
+
+The procedure is:
+
+1. Compute the centroid of each class in the `(x_i, x_j)` plane using the rows at the current node.
+2. Find the class pair whose centroids are furthest apart in Euclidean distance.
+3. Use the vector from one centroid to the other as the raw weight direction `(dx, dy)`.
+4. Normalize to unit length: `w1 = dx / norm`, `w2 = dy / norm`.
+
+This is a discriminant-direction heuristic. It projects rows along the axis that maximally separates the most distant class pair, then scores all possible thresholds along that axis.
+
+### Regression
+
+For regression, ForestFire uses the covariance of each feature with the target.
+
+The procedure is:
+
+1. For each feature in the pair, compute `cov(x_k, y)` over the rows at the current node using mean-centered values.
+2. Treat those two covariances as the raw weight vector `(w1_raw, w2_raw)`.
+3. Normalize to unit length.
+
+This finds the direction in the 2D subspace that is most correlated with the target, which is the direction of steepest gradient in that feature plane.
+
+### Second-order (GBM)
+
+For second-order gradient boosting trees, the same gradient-direction approach applies but uses per-row gradients and Hessians from the current ensemble state rather than raw target values.
+
+### Threshold selection
+
+Once weights are fixed for a candidate pair, ForestFire:
+
+1. Projects each node row with complete values onto the learned direction: `value = w1 * x_i + w2 * x_j`.
+2. Sorts those projected values.
+3. Evaluates midpoints between consecutive distinct projected values as candidate thresholds.
+4. Chooses the threshold that produces the best split score.
+
+This is the same threshold-scanning logic used for axis-aligned splits, applied to the projected 1D space.
+
+## Candidate enumeration
+
+For a node with `k` candidate features, ForestFire generates all unordered pairs. That is `k * (k - 1) / 2` candidate pairs.
+
+Each pair generates one oblique candidate using its independently computed weight vector and best threshold. Those oblique candidates join the pool of axis-aligned candidates.
+
+Example: if `max_features=4` at a node, there are `6` axis-aligned candidates and `6` oblique candidates for a total pool of `12` before canary competition.
+
+## Competition with axis-aligned candidates
+
+Oblique and axis-aligned candidates compete in the same ranked pool.
+
+Both are scored by the same objective: Gini impurity reduction for classification, MSE reduction for regression, or the second-order gain criterion for boosting. The candidate with the best score wins the node, regardless of split type.
+
+No preference is given to either family. An oblique split wins only if its projected linear boundary produces a better score than any single-feature threshold at the same node.
+
+That means oblique splits do not add a "bias toward complex splits." They compete on the same footing. When the true signal is axis-aligned, axis-aligned candidates typically win. When the signal is better captured by a linear combination, oblique candidates do.
+
+## Canary interaction
+
+Oblique splits interact with canaries the same way axis-aligned splits do.
+
+For each real feature pair `(x_i, x_j)`, ForestFire generates a corresponding canary pair using shuffled copies of those two features. That canary pair enters the competition pool alongside the real oblique and real axis-aligned candidates.
+
+The canary acceptance rule is identical:
+
+- candidates are scored and sorted
+- the `filter` window determines how far down the ranked list the chosen real split can fall
+- if no real candidate (axis-aligned or oblique) survives inside the allowed window, the node stops
+
+This keeps the same "better than structured noise" guarantee for both split families. An oblique node that would only win against canaries is treated as no signal, not as a special case.
+
+For the full canary algorithm, see [Canary Strategy](canaries.md).
+
+## Missing-value handling
+
+Oblique splits handle missing values per participating feature rather than as a single node-level fallback.
+
+When a row arrives at an oblique node and one of its two participating features is missing, ForestFire routes it using the missing-direction learned for that specific feature. When both features are missing and the two learned directions disagree, the tie is broken by the feature with the larger absolute weight.
+
+For the full missing-routing semantics and decision rules, see [Missing-Value Handling: Oblique split behavior](missing-values.md#oblique-split-behavior).
+
+## Support matrix
+
+- `split_strategy="axis_aligned"`: supported for all tree families and algorithms
+- `split_strategy="oblique"`: supported for `dt`, `rf`, and `gbm` when `tree_type` is `cart` or `randomized`
+
+Not currently supported for:
+
+- `id3` and `c45`: these are multiway classifiers. Their split model is not a binary threshold over one scalar, so pairwise linear splits do not compose with their branch structure.
+- `oblivious`: oblivious trees share one split per depth across all nodes at that level. A single shared oblique split with learned pair-specific weights does not map cleanly onto that level-sharing model.
+
+## Current limitations
+
+- **Pairwise only.** The current implementation is limited to exactly two features per oblique node. Arbitrary `k`-feature hyperplanes are not yet supported.
+- **All pairs considered.** Every candidate pair at a node is always evaluated. There is no adaptive search budget or pair-pruning heuristic for large feature spaces yet.
+- **Row-wise inference.** The optimized runtime for oblique nodes uses a standard row-wise dot-product evaluation. A batched or SIMD-accelerated projection path is planned but not yet implemented.
+
+## When to use oblique splits
+
+Use oblique splits when the problem has known or suspected structure across feature pairs:
+
+- numeric features that are correlated and jointly predictive
+- decision surfaces that are rotated relative to the feature axes
+- tasks where shallower, more expressive trees are preferred over many small axis-aligned fragments
+
+Oblique splits are also useful inside gradient boosting. Each stage fits trees to residual structure, and residual structure can be diagonal in feature space even when the original target was not.
+
+Start with axis-aligned splits for a baseline. Try oblique splits when:
+
+- axis-aligned trees are growing very deep on structured data
+- you believe pairs of features interact in ways that a single threshold misses
+- you want to compare shallower trees against the axis-aligned baseline
+
+### Tradeoffs
+
+**Training cost:** Every candidate feature pair generates one oblique candidate. For a node with `k` candidate features, this multiplies the candidate pool. On large feature spaces, training with oblique splits can be substantially slower than axis-aligned training.
+
+**Inference cost:** Each oblique node requires a dot product plus one threshold comparison rather than one threshold comparison alone. This is a modest constant-factor overhead per node, not a change in asymptotic complexity.
+
+**Interpretability:** Each oblique node depends on two features. A node condition like `0.71 * x_3 + 0.71 * x_7 <= 0.4` is harder to read than `x_3 <= 0.4`. For use cases where human-readable trees matter, this is a real tradeoff.
+
+**When axis-aligned wins anyway:** If the true decision boundary is axis-aligned, oblique candidates still compete but do not win. The competition is fair; the cost is the extra computation for generating and scoring those candidates before they lose.
+
+## Usage examples
+
+### Decision tree with oblique splits
+
+```python
+import numpy as np
+from forestfire import train
+
+rng = np.random.default_rng(42)
+n = 10_000
+
+# Rotated boundary: the rule is x_0 + x_1 > 0.5
+X = rng.normal(size=(n, 6))
+y = (X[:, 0] + X[:, 1] > 0.5).astype(float)
+
+# Axis-aligned baseline: needs many nodes to approximate the diagonal boundary
+model_aa = train(
+    X,
+    y,
+    algorithm="dt",
+    tree_type="cart",
+    task="classification",
+)
+
+# Oblique: the diagonal boundary can be expressed in far fewer nodes
+model_ob = train(
+    X,
+    y,
+    algorithm="dt",
+    tree_type="cart",
+    task="classification",
+    split_strategy="oblique",
+)
+
+print(model_aa.tree_structure())
+print(model_ob.tree_structure())
+```
+
+### Random forest with oblique splits
+
+```python
+model_rf = train(
+    X,
+    y,
+    algorithm="rf",
+    tree_type="cart",
+    task="classification",
+    split_strategy="oblique",
+    n_trees=200,
+    max_features="sqrt",
+)
+```
+
+### Gradient boosting with oblique splits
+
+```python
+model_gbm = train(
+    X,
+    y,
+    algorithm="gbm",
+    tree_type="cart",
+    task="classification",
+    split_strategy="oblique",
+    learning_rate=0.05,
+    n_trees=500,
+    canaries=2,
+    filter=0.95,
+)
+```
+
+### Inspecting oblique nodes
+
+Oblique split nodes appear in tree introspection alongside axis-aligned nodes. The `tree_structure()` and `tree_node()` methods expose them using the same interface, but the split description now includes two feature indices and their corresponding weights.
+
+```python
+model = train(
+    X,
+    y,
+    algorithm="dt",
+    tree_type="cart",
+    task="classification",
+    split_strategy="oblique",
+)
+
+print(model.tree_structure())
+print(model.tree_node(node_id=0, tree_index=0))
+
+ir = model.to_ir_json()
+```
+
+In the IR, oblique nodes appear as `ObliqueLinearCombination` splits with:
+
+- `feature_indices`: the two participating feature positions
+- `weights`: the two normalized weight values
+- `threshold`: the learned threshold in projected space
+- `missing_directions`: the per-feature learned missing routing
+
+### Oblique splits with randomized trees
+
+Randomized tree families introduce stochasticity into split search. Oblique splits compose naturally with that: the randomized tree still evaluates multiple threshold candidates per pair, with oblique and axis-aligned candidates competing in the usual way.
+
+```python
+model_rand_ob = train(
+    X,
+    y,
+    algorithm="dt",
+    tree_type="randomized",
+    task="classification",
+    split_strategy="oblique",
+    seed=7,
+)
+```
+
+## Why the implementation is pairwise
+
+Extending to arbitrary `k`-feature hyperplanes would allow the split to express any linear boundary, not just one between two features. That is a more powerful hypothesis class.
+
+The reasons for starting at pairs are:
+
+- **Search cost.** For `k` selected features, all unordered pairs is `O(k^2)`. All `m`-feature subsets for `m > 2` grows combinatorially. Without a principled search heuristic, the candidate space becomes impractical.
+- **Weight estimation.** The current weight estimation procedure is closed-form and cheap. Estimating the best direction for `m > 2` features well requires either more data per node or a more expensive optimization step.
+- **Interpretability floor.** Two-feature oblique nodes are already less interpretable than single-feature thresholds. Going beyond pairs reduces interpretability further without a compelling accuracy justification for most tabular problems.
+
+Pairwise oblique splits hit a useful point in the tradeoff space:
+
+- they capture the most common multi-feature structure (correlated pairs and diagonal boundaries)
+- without an exponential search cost or complex weight estimation
+- while remaining reasonably close to what a practitioner can inspect
+
+The roadmap includes moving beyond pairwise splits as optional experimental extension once adaptive search budgeting and stronger pair-selection heuristics are in place.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Examples: examples.md
   - Training: training.md
   - Categorical Strategies: categorical-strategies.md
+  - Oblique Splits: oblique-splits.md
   - Models And Introspection: models.md
   - Benchmarks: benchmarks.md
   - Next Steps: next-steps.md


### PR DESCRIPTION
- create docs/oblique-splits.md: comprehensive dedicated page covering weight computation (classification vs regression), candidate enumeration, axis-aligned competition, canary interaction, missing-value routing, support matrix, current limitations, usage examples, and the rationale for staying pairwise
- add Example 4 to docs/examples.md: full oblique workflow comparing axis-aligned vs oblique across DT/RF/GBM with serialize-reload and IR inspection
- update docs/index.md and mkdocs.yml to include oblique-splits.md in the documentation map and site navigation
- replace stale categorical next-steps section with an updated version that acknowledges dummy/target/fisher as implemented and scopes remaining work to native subset splits and leakage controls