### PR TITLE
implement beam builder

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forestfire-python"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 publish = false
 license = "MIT"
@@ -17,5 +17,5 @@ numpy = "0.26"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-forestfire-core = { version = "0.5.1", path = "../../crates/core" }
-forestfire-data = { version = "0.5.1", path = "../../crates/data" }
+forestfire-core = { version = "0.5.2", path = "../../crates/core" }
+forestfire-data = { version = "0.5.2", path = "../../crates/data" }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "forestfire-ml"
-version = "0.5.1"
+version = "0.5.2"
 description = "Tree-based learning in Rust with a Python API."
 readme = "PYPI.md"
 license = "MIT"

--- a/bindings/python/python/forestfire/_core.pyi
+++ b/bindings/python/python/forestfire/_core.pyi
@@ -36,6 +36,7 @@ def train(
     lookahead_depth: int = 1,
     lookahead_top_k: int = 8,
     lookahead_weight: float = 1.0,
+    beam_width: int = 4,
     n_trees: int | None = None,
     max_features: str | int | None = None,
     seed: int | None = None,

--- a/bindings/python/python/forestfire/_sklearn.py
+++ b/bindings/python/python/forestfire/_sklearn.py
@@ -137,6 +137,7 @@ class _TreeClassifierBase(_ForestFireClassifier):
         lookahead_depth: int = 1,
         lookahead_top_k: int = 8,
         lookahead_weight: float = 1.0,
+        beam_width: int = 4,
         n_jobs: int | None = None,
         random_state: int | None = None,
         missing_value_strategy: str | dict[str, str] = "heuristic",
@@ -156,6 +157,7 @@ class _TreeClassifierBase(_ForestFireClassifier):
         self.lookahead_depth = lookahead_depth
         self.lookahead_top_k = lookahead_top_k
         self.lookahead_weight = lookahead_weight
+        self.beam_width = beam_width
         self.n_jobs = n_jobs
         self.random_state = random_state
         self.missing_value_strategy = missing_value_strategy
@@ -184,6 +186,7 @@ class _TreeClassifierBase(_ForestFireClassifier):
             lookahead_depth=self.lookahead_depth,
             lookahead_top_k=self.lookahead_top_k,
             lookahead_weight=self.lookahead_weight,
+            beam_width=self.beam_width,
             seed=self.random_state,
             missing_value_strategy=self.missing_value_strategy,
             split_strategy=self.split_strategy,
@@ -211,6 +214,7 @@ class _TreeRegressorBase(_ForestFireRegressor):
         lookahead_depth: int = 1,
         lookahead_top_k: int = 8,
         lookahead_weight: float = 1.0,
+        beam_width: int = 4,
         n_jobs: int | None = None,
         random_state: int | None = None,
         missing_value_strategy: str | dict[str, str] = "heuristic",
@@ -230,6 +234,7 @@ class _TreeRegressorBase(_ForestFireRegressor):
         self.lookahead_depth = lookahead_depth
         self.lookahead_top_k = lookahead_top_k
         self.lookahead_weight = lookahead_weight
+        self.beam_width = beam_width
         self.n_jobs = n_jobs
         self.random_state = random_state
         self.missing_value_strategy = missing_value_strategy
@@ -258,6 +263,7 @@ class _TreeRegressorBase(_ForestFireRegressor):
             lookahead_depth=self.lookahead_depth,
             lookahead_top_k=self.lookahead_top_k,
             lookahead_weight=self.lookahead_weight,
+            beam_width=self.beam_width,
             seed=self.random_state,
             missing_value_strategy=self.missing_value_strategy,
             split_strategy=self.split_strategy,
@@ -286,6 +292,7 @@ class _ForestClassifierBase(_ForestFireClassifier):
         lookahead_depth: int = 1,
         lookahead_top_k: int = 8,
         lookahead_weight: float = 1.0,
+        beam_width: int = 4,
         max_features: str | int | None = None,
         n_jobs: int | None = None,
         random_state: int | None = None,
@@ -308,6 +315,7 @@ class _ForestClassifierBase(_ForestFireClassifier):
         self.lookahead_depth = lookahead_depth
         self.lookahead_top_k = lookahead_top_k
         self.lookahead_weight = lookahead_weight
+        self.beam_width = beam_width
         self.max_features = max_features
         self.n_jobs = n_jobs
         self.random_state = random_state
@@ -338,6 +346,7 @@ class _ForestClassifierBase(_ForestFireClassifier):
             lookahead_depth=self.lookahead_depth,
             lookahead_top_k=self.lookahead_top_k,
             lookahead_weight=self.lookahead_weight,
+            beam_width=self.beam_width,
             n_trees=self.n_estimators,
             max_features=self.max_features,
             seed=self.random_state,
@@ -369,6 +378,7 @@ class _ForestRegressorBase(_ForestFireRegressor):
         lookahead_depth: int = 1,
         lookahead_top_k: int = 8,
         lookahead_weight: float = 1.0,
+        beam_width: int = 4,
         max_features: str | int | None = None,
         n_jobs: int | None = None,
         random_state: int | None = None,
@@ -391,6 +401,7 @@ class _ForestRegressorBase(_ForestFireRegressor):
         self.lookahead_depth = lookahead_depth
         self.lookahead_top_k = lookahead_top_k
         self.lookahead_weight = lookahead_weight
+        self.beam_width = beam_width
         self.max_features = max_features
         self.n_jobs = n_jobs
         self.random_state = random_state
@@ -421,6 +432,7 @@ class _ForestRegressorBase(_ForestFireRegressor):
             lookahead_depth=self.lookahead_depth,
             lookahead_top_k=self.lookahead_top_k,
             lookahead_weight=self.lookahead_weight,
+            beam_width=self.beam_width,
             n_trees=self.n_estimators,
             max_features=self.max_features,
             seed=self.random_state,
@@ -451,6 +463,7 @@ class _GBMClassifierBase(_ForestFireClassifier):
         lookahead_depth: int = 1,
         lookahead_top_k: int = 8,
         lookahead_weight: float = 1.0,
+        beam_width: int = 4,
         learning_rate: float | None = None,
         bootstrap: bool = False,
         top_gradient_fraction: float | None = None,
@@ -474,6 +487,7 @@ class _GBMClassifierBase(_ForestFireClassifier):
         self.lookahead_depth = lookahead_depth
         self.lookahead_top_k = lookahead_top_k
         self.lookahead_weight = lookahead_weight
+        self.beam_width = beam_width
         self.learning_rate = learning_rate
         self.bootstrap = bootstrap
         self.top_gradient_fraction = top_gradient_fraction
@@ -505,6 +519,7 @@ class _GBMClassifierBase(_ForestFireClassifier):
             lookahead_depth=self.lookahead_depth,
             lookahead_top_k=self.lookahead_top_k,
             lookahead_weight=self.lookahead_weight,
+            beam_width=self.beam_width,
             n_trees=self.n_estimators,
             seed=self.random_state,
             learning_rate=self.learning_rate,
@@ -537,6 +552,7 @@ class _GBMRegressorBase(_ForestFireRegressor):
         lookahead_depth: int = 1,
         lookahead_top_k: int = 8,
         lookahead_weight: float = 1.0,
+        beam_width: int = 4,
         learning_rate: float | None = None,
         bootstrap: bool = False,
         top_gradient_fraction: float | None = None,
@@ -560,6 +576,7 @@ class _GBMRegressorBase(_ForestFireRegressor):
         self.lookahead_depth = lookahead_depth
         self.lookahead_top_k = lookahead_top_k
         self.lookahead_weight = lookahead_weight
+        self.beam_width = beam_width
         self.learning_rate = learning_rate
         self.bootstrap = bootstrap
         self.top_gradient_fraction = top_gradient_fraction
@@ -591,6 +608,7 @@ class _GBMRegressorBase(_ForestFireRegressor):
             lookahead_depth=self.lookahead_depth,
             lookahead_top_k=self.lookahead_top_k,
             lookahead_weight=self.lookahead_weight,
+            beam_width=self.beam_width,
             n_trees=self.n_estimators,
             seed=self.random_state,
             learning_rate=self.learning_rate,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1769,8 +1769,9 @@ fn parse_builder(builder: &str) -> PyResult<BuilderStrategy> {
     match builder {
         "greedy" => Ok(BuilderStrategy::Greedy),
         "lookahead" => Ok(BuilderStrategy::Lookahead),
+        "beam" => Ok(BuilderStrategy::Beam),
         _ => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-            "Unsupported builder '{}'. Expected one of: greedy, lookahead",
+            "Unsupported builder '{}'. Expected one of: greedy, lookahead, beam",
             builder
         ))),
     }
@@ -2168,7 +2169,7 @@ fn tree_type_name(tree_type: TreeType) -> &'static str {
 }
 
 #[pyfunction]
-#[pyo3(signature = (x, y=None, algorithm="dt", task="auto", tree_type="cart", split_strategy="axis_aligned", builder="greedy", criterion="auto", canaries=2, bins=None, histogram_bins=None, physical_cores=None, max_depth=None, min_samples_split=None, min_samples_leaf=None, lookahead_depth=1, lookahead_top_k=8, lookahead_weight=1.0, n_trees=None, max_features=None, seed=None, compute_oob=false, learning_rate=None, bootstrap=false, top_gradient_fraction=None, other_gradient_fraction=None, missing_value_strategy=None, filter=None, categorical_strategy=None, categorical_features=None, target_smoothing=20.0))]
+#[pyo3(signature = (x, y=None, algorithm="dt", task="auto", tree_type="cart", split_strategy="axis_aligned", builder="greedy", criterion="auto", canaries=2, bins=None, histogram_bins=None, physical_cores=None, max_depth=None, min_samples_split=None, min_samples_leaf=None, lookahead_depth=1, lookahead_top_k=8, lookahead_weight=1.0, beam_width=4, n_trees=None, max_features=None, seed=None, compute_oob=false, learning_rate=None, bootstrap=false, top_gradient_fraction=None, other_gradient_fraction=None, missing_value_strategy=None, filter=None, categorical_strategy=None, categorical_features=None, target_smoothing=20.0))]
 #[allow(clippy::too_many_arguments)]
 fn train(
     py: Python<'_>,
@@ -2190,6 +2191,7 @@ fn train(
     lookahead_depth: usize,
     lookahead_top_k: usize,
     lookahead_weight: f64,
+    beam_width: usize,
     n_trees: Option<usize>,
     max_features: Option<&Bound<PyAny>>,
     seed: Option<u64>,
@@ -2221,6 +2223,7 @@ fn train(
         lookahead_depth: parse_positive_usize(lookahead_depth, "lookahead_depth")?,
         lookahead_top_k: parse_positive_usize(lookahead_top_k, "lookahead_top_k")?,
         lookahead_weight: parse_nonnegative_f64(lookahead_weight, "lookahead_weight")?,
+        beam_width: parse_positive_usize(beam_width, "beam_width")?,
         physical_cores,
         n_trees,
         max_features: parse_max_features(max_features)?,

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forestfire-core"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/wsperat/forest-fire"
@@ -12,7 +12,7 @@ polars = ["dep:polars"]
 
 [dependencies]
 arrow.workspace = true
-forestfire-data = { version = "0.5.1", path = "../data" }
+forestfire-data = { version = "0.5.2", path = "../data" }
 num_cpus.workspace = true
 rand.workspace = true
 polars = { version = "0.46", optional = true, default-features = false, features = ["lazy"] }

--- a/crates/core/src/boosting.rs
+++ b/crates/core/src/boosting.rs
@@ -189,6 +189,7 @@ impl GradientBoostedTrees {
             lookahead_depth: config.lookahead_depth,
             lookahead_top_k: config.lookahead_top_k,
             lookahead_weight: config.lookahead_weight,
+            beam_width: config.beam_width,
         };
         let tree_options = SecondOrderRegressionTreeOptions {
             tree_options,

--- a/crates/core/src/forest.rs
+++ b/crates/core/src/forest.rs
@@ -128,6 +128,7 @@ impl RandomForest {
                         lookahead_depth: config.lookahead_depth,
                         lookahead_top_k: config.lookahead_top_k,
                         lookahead_weight: config.lookahead_weight,
+                        beam_width: config.beam_width,
                     },
                     max_features: Some(max_features),
                     random_seed: tree_seed,

--- a/crates/core/src/ir.rs
+++ b/crates/core/src/ir.rs
@@ -796,6 +796,7 @@ fn boosted_tree_model_from_ir_parts(
                     lookahead_depth: 1,
                     lookahead_top_k: 8,
                     lookahead_weight: 1.0,
+                    beam_width: 4,
                 },
                 num_features,
                 feature_preprocessing,
@@ -828,6 +829,7 @@ fn boosted_tree_model_from_ir_parts(
                         lookahead_depth: 1,
                         lookahead_top_k: 8,
                         lookahead_weight: 1.0,
+                        beam_width: 4,
                     },
                     num_features,
                     feature_preprocessing,
@@ -949,6 +951,7 @@ fn single_model_from_ir_parts(
                     lookahead_depth: 1,
                     lookahead_top_k: 8,
                     lookahead_weight: 1.0,
+                    beam_width: 4,
                 },
                 num_features,
                 feature_preprocessing,
@@ -985,6 +988,7 @@ fn single_model_from_ir_parts(
                         lookahead_depth: 1,
                         lookahead_top_k: 8,
                         lookahead_weight: 1.0,
+                        beam_width: 4,
                     },
                     num_features,
                     feature_preprocessing,
@@ -1092,6 +1096,7 @@ fn tree_options(training: &TrainingMetadata) -> DecisionTreeOptions {
         lookahead_depth: 1,
         lookahead_top_k: 8,
         lookahead_weight: 1.0,
+        beam_width: 4,
     }
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -166,6 +166,8 @@ pub enum BuilderStrategy {
     Greedy,
     /// Rank splits by a finite lookahead horizon.
     Lookahead,
+    /// Rank splits by a width-limited continuation search.
+    Beam,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -347,6 +349,8 @@ pub struct TrainConfig {
     pub lookahead_top_k: usize,
     /// Weight applied to future split value when lookahead rescoring is enabled.
     pub lookahead_weight: f64,
+    /// Number of continuation candidates kept alive at each lookahead step for beam search.
+    pub beam_width: usize,
 }
 
 impl Default for TrainConfig {
@@ -376,6 +380,7 @@ impl Default for TrainConfig {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
         }
     }
 }
@@ -420,6 +425,7 @@ pub enum TrainError {
     InvalidLookaheadDepth(usize),
     InvalidLookaheadTopK(usize),
     InvalidLookaheadWeight(f64),
+    InvalidBeamWidth(usize),
     InvalidTreeCount(usize),
     InvalidMaxFeatures(usize),
     InvalidCanaryFilterTopN(usize),
@@ -495,6 +501,9 @@ impl Display for TrainError {
                     "lookahead_weight must be finite and non-negative. Received {}.",
                     value
                 )
+            }
+            TrainError::InvalidBeamWidth(value) => {
+                write!(f, "beam_width must be at least 1. Received {}.", value)
             }
             TrainError::InvalidTreeCount(n_trees) => {
                 write!(

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -66,6 +66,7 @@ fn unified_train_dispatches_regression_cart() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -124,6 +125,7 @@ fn unified_train_dispatches_randomized_for_both_tasks() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -145,6 +147,7 @@ fn unified_train_dispatches_randomized_for_both_tasks() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -181,6 +184,7 @@ fn unified_train_rejects_unsupported_task_tree_pair() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -228,6 +232,7 @@ fn unified_train_accepts_oblique_strategy_for_gbm_cart() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Auto,
             n_trees: Some(4),
             max_depth: Some(1),
@@ -254,6 +259,7 @@ fn oblique_models_round_trip_through_ir_and_optimized_runtime() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: Some(1),
             max_features: MaxFeatures::Count(2),
@@ -310,6 +316,7 @@ fn unified_train_resolves_auto_criterion_across_supported_matrix() {
                 lookahead_depth: 1,
                 lookahead_top_k: 8,
                 lookahead_weight: 1.0,
+                beam_width: 4,
                 criterion: Criterion::Auto,
                 max_depth: None,
 
@@ -342,6 +349,7 @@ fn unified_train_resolves_auto_criterion_across_supported_matrix() {
                 lookahead_depth: 1,
                 lookahead_top_k: 8,
                 lookahead_weight: 1.0,
+                beam_width: 4,
                 criterion: Criterion::Auto,
                 max_depth: None,
 
@@ -374,6 +382,7 @@ fn unified_train_resolves_auto_criterion_across_supported_matrix() {
                 lookahead_depth: 1,
                 lookahead_top_k: 8,
                 lookahead_weight: 1.0,
+                beam_width: 4,
                 criterion: Criterion::Auto,
                 max_depth: None,
 
@@ -406,6 +415,7 @@ fn unified_train_resolves_auto_criterion_across_supported_matrix() {
                 lookahead_depth: 1,
                 lookahead_top_k: 8,
                 lookahead_weight: 1.0,
+                beam_width: 4,
                 criterion: Criterion::Auto,
                 max_depth: None,
 
@@ -438,6 +448,7 @@ fn unified_train_resolves_auto_criterion_across_supported_matrix() {
                 lookahead_depth: 1,
                 lookahead_top_k: 8,
                 lookahead_weight: 1.0,
+                beam_width: 4,
                 criterion: Criterion::Auto,
                 max_depth: None,
 
@@ -470,6 +481,7 @@ fn unified_train_resolves_auto_criterion_across_supported_matrix() {
                 lookahead_depth: 1,
                 lookahead_top_k: 8,
                 lookahead_weight: 1.0,
+                beam_width: 4,
                 criterion: Criterion::Auto,
                 max_depth: None,
 
@@ -502,6 +514,7 @@ fn unified_train_resolves_auto_criterion_across_supported_matrix() {
                 lookahead_depth: 1,
                 lookahead_top_k: 8,
                 lookahead_weight: 1.0,
+                beam_width: 4,
                 criterion: Criterion::Auto,
                 max_depth: None,
 
@@ -534,6 +547,7 @@ fn unified_train_resolves_auto_criterion_across_supported_matrix() {
                 lookahead_depth: 1,
                 lookahead_top_k: 8,
                 lookahead_weight: 1.0,
+                beam_width: 4,
                 criterion: Criterion::Auto,
                 max_depth: None,
 
@@ -602,6 +616,7 @@ fn unified_train_parallel_matches_single_core_across_supported_tree_types() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -630,6 +645,7 @@ fn unified_train_parallel_matches_single_core_across_supported_tree_types() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -658,6 +674,7 @@ fn unified_train_parallel_matches_single_core_across_supported_tree_types() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -708,6 +725,7 @@ fn unified_train_parallel_matches_single_core_across_supported_tree_types() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Entropy,
             max_depth: None,
 
@@ -736,6 +754,7 @@ fn unified_train_parallel_matches_single_core_across_supported_tree_types() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Entropy,
             max_depth: None,
 
@@ -764,6 +783,7 @@ fn unified_train_parallel_matches_single_core_across_supported_tree_types() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -792,6 +812,7 @@ fn unified_train_parallel_matches_single_core_across_supported_tree_types() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -820,6 +841,7 @@ fn unified_train_parallel_matches_single_core_across_supported_tree_types() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -909,6 +931,7 @@ fn unified_train_caps_physical_cores_to_available_hardware() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -941,6 +964,7 @@ fn unified_train_caps_physical_cores_to_available_hardware() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -994,6 +1018,7 @@ fn ir_exports_regression_tree_with_training_binning() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -1066,6 +1091,7 @@ fn ir_exports_classifier_with_multiway_postprocessing() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Entropy,
             max_depth: None,
 
@@ -1132,6 +1158,7 @@ fn ir_exports_oblivious_regressor_with_msb_leaf_indexing() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -1200,6 +1227,7 @@ fn serialized_model_round_trips_through_deserialize() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -1256,6 +1284,7 @@ fn optimized_model_matches_base_model_and_ir_for_standard_classifier() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -1321,6 +1350,7 @@ fn optimized_model_matches_base_model_and_ir_for_oblivious_regressor() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -1382,6 +1412,7 @@ fn optimized_oblivious_model_matches_base_on_large_batch() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -1434,6 +1465,7 @@ fn optimized_cart_model_batch_and_single_row_predictions_match() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -1489,6 +1521,7 @@ fn optimized_oblivious_model_batch_and_single_row_predictions_match() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -1547,6 +1580,7 @@ fn compiled_artifact_round_trips_for_binary_classifier_runtime() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -1619,6 +1653,7 @@ fn optimized_model_projects_ensemble_inputs_to_used_features() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             n_trees: Some(8),
             max_features: MaxFeatures::Count(2),
@@ -1661,6 +1696,7 @@ fn compiled_artifact_round_trips_for_oblivious_regressor_runtime() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -1724,6 +1760,7 @@ fn compiled_artifact_round_trips_for_boosted_binary_classifier_runtime() {
                 lookahead_depth: 1,
                 lookahead_top_k: 8,
                 lookahead_weight: 1.0,
+                beam_width: 4,
                 criterion: Criterion::SecondOrder,
                 n_trees: Some(16),
                 learning_rate: Some(0.2),
@@ -1793,6 +1830,7 @@ fn optimized_model_rejects_zero_physical_cores() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -1847,6 +1885,7 @@ fn model_predicts_from_raw_rows_without_building_a_training_table() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -1905,6 +1944,7 @@ fn model_predicts_from_named_columns() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -1961,6 +2001,7 @@ fn model_rejects_missing_named_feature() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -2016,6 +2057,7 @@ fn optimized_classifier_preserves_missing_routing() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
             min_samples_split: None,
@@ -2070,6 +2112,7 @@ fn optimized_regressor_preserves_missing_routing() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
             min_samples_split: None,
@@ -2117,6 +2160,7 @@ fn optimized_missing_feature_configuration_can_skip_missing_checks() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
             min_samples_split: None,
@@ -2176,6 +2220,7 @@ fn model_rejects_unexpected_named_feature() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -2233,6 +2278,7 @@ fn model_rejects_invalid_binary_value_during_inference() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -2291,6 +2337,7 @@ fn model_predicts_from_sparse_binary_columns() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -2345,6 +2392,7 @@ fn model_predicts_from_polars_dataframe() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -2402,6 +2450,7 @@ fn model_predicts_from_polars_lazyframe() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -2459,6 +2508,7 @@ fn model_and_optimized_model_predict_large_polars_lazyframes_in_batches() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -2538,6 +2588,7 @@ fn model_rejects_polars_nulls() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -2596,6 +2647,7 @@ fn ir_serializes_node_stats_for_standard_and_oblivious_trees() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -2652,6 +2704,7 @@ fn ir_serializes_node_stats_for_standard_and_oblivious_trees() {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 
@@ -2800,6 +2853,7 @@ fn lookahead_depth_trains_across_tree_families() {
                 lookahead_depth: 2,
                 lookahead_top_k: 8,
                 lookahead_weight: 1.0,
+                beam_width: 4,
                 criterion: Criterion::Auto,
                 max_depth: Some(3),
                 min_samples_split: Some(2),

--- a/crates/core/src/training.rs
+++ b/crates/core/src/training.rs
@@ -300,6 +300,9 @@ pub fn train(train_set: &dyn TableAccess, config: TrainConfig) -> Result<Model, 
     if !config.lookahead_weight.is_finite() || config.lookahead_weight < 0.0 {
         return Err(TrainError::InvalidLookaheadWeight(config.lookahead_weight));
     }
+    if config.beam_width == 0 {
+        return Err(TrainError::InvalidBeamWidth(config.beam_width));
+    }
     config.canary_filter.validate()?;
 
     // Parallelism is installed around the whole training call so nested trainers
@@ -322,6 +325,7 @@ pub fn train(train_set: &dyn TableAccess, config: TrainConfig) -> Result<Model, 
                 lookahead_depth: config.lookahead_depth,
                 lookahead_top_k: config.lookahead_top_k,
                 lookahead_weight: config.lookahead_weight,
+                beam_width: config.beam_width,
             },
         ),
         TrainAlgorithm::Rf => train_random_forest(
@@ -344,6 +348,7 @@ pub fn train(train_set: &dyn TableAccess, config: TrainConfig) -> Result<Model, 
                 lookahead_depth: config.lookahead_depth,
                 lookahead_top_k: config.lookahead_top_k,
                 lookahead_weight: config.lookahead_weight,
+                beam_width: config.beam_width,
             },
         ),
         TrainAlgorithm::Gbm => train_gradient_boosting(
@@ -373,6 +378,7 @@ pub(crate) struct SingleModelConfig {
     pub(crate) lookahead_depth: usize,
     pub(crate) lookahead_top_k: usize,
     pub(crate) lookahead_weight: f64,
+    pub(crate) beam_width: usize,
 }
 
 /// Internal single-tree config with optional per-node feature subsampling.
@@ -405,6 +411,7 @@ pub(crate) struct RandomForestConfig {
     pub(crate) lookahead_depth: usize,
     pub(crate) lookahead_top_k: usize,
     pub(crate) lookahead_weight: f64,
+    pub(crate) beam_width: usize,
 }
 
 pub(crate) fn train_single_model(
@@ -442,6 +449,7 @@ pub(crate) fn train_single_model_with_feature_subset(
                 lookahead_depth,
                 lookahead_top_k,
                 lookahead_weight,
+                beam_width,
             },
         max_features,
         random_seed,
@@ -459,6 +467,7 @@ pub(crate) fn train_single_model_with_feature_subset(
         lookahead_depth,
         lookahead_top_k,
         lookahead_weight,
+        beam_width,
     };
     let regressor_options = tree::regressor::RegressionTreeOptions {
         max_depth,
@@ -473,6 +482,7 @@ pub(crate) fn train_single_model_with_feature_subset(
         lookahead_depth,
         lookahead_top_k,
         lookahead_weight,
+        beam_width,
     };
 
     match (task, tree_type, criterion) {

--- a/crates/core/src/tree/classifier.rs
+++ b/crates/core/src/tree/classifier.rs
@@ -87,6 +87,7 @@ pub struct DecisionTreeOptions {
     pub lookahead_depth: usize,
     pub lookahead_top_k: usize,
     pub lookahead_weight: f64,
+    pub beam_width: usize,
 }
 
 impl Default for DecisionTreeOptions {
@@ -104,6 +105,7 @@ impl Default for DecisionTreeOptions {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
         }
     }
 }
@@ -112,7 +114,14 @@ impl DecisionTreeOptions {
     fn effective_lookahead_depth(&self) -> usize {
         match self.builder {
             BuilderStrategy::Greedy => 1,
-            BuilderStrategy::Lookahead => self.lookahead_depth,
+            BuilderStrategy::Lookahead | BuilderStrategy::Beam => self.lookahead_depth,
+        }
+    }
+
+    fn effective_beam_width(&self) -> usize {
+        match self.builder {
+            BuilderStrategy::Greedy | BuilderStrategy::Lookahead => 1,
+            BuilderStrategy::Beam => self.beam_width,
         }
     }
 }
@@ -1368,14 +1377,19 @@ fn standard_split_ranking_score(
         ),
     };
     let (left_rows, right_rows) = partitioned_rows.split_at_mut(left_count);
-    let future =
-        best_standard_split_lookahead_score(context, left_rows, depth + 1, lookahead_depth - 1)
-            + best_standard_split_lookahead_score(
-                context,
-                right_rows,
-                depth + 1,
-                lookahead_depth - 1,
-            );
+    let future = best_standard_split_lookahead_score(
+        context,
+        left_rows,
+        depth + 1,
+        lookahead_depth - 1,
+        context.options.effective_beam_width(),
+    ) + best_standard_split_lookahead_score(
+        context,
+        right_rows,
+        depth + 1,
+        lookahead_depth - 1,
+        context.options.effective_beam_width(),
+    );
     immediate + context.options.lookahead_weight * future
 }
 
@@ -1384,6 +1398,7 @@ fn best_standard_split_lookahead_score(
     rows: &mut [usize],
     depth: usize,
     lookahead_depth: usize,
+    beam_width: usize,
 ) -> f64 {
     if rows.is_empty()
         || lookahead_depth == 0
@@ -1428,23 +1443,21 @@ fn best_standard_split_lookahead_score(
             )
         })
         .collect::<Vec<_>>();
-    select_best_non_canary_candidate(
-        context.table,
-        rank_standard_split_choices(
-            context,
-            rows,
-            depth,
-            &current_class_counts,
-            &split_candidates,
-            &feature_indices,
-            lookahead_depth,
-        ),
-        context.options.canary_filter,
-        |candidate| candidate.ranking_score,
-        |candidate| candidate.choice.ranking_feature_index(),
-    )
-    .selected
-    .map_or(0.0, |candidate| candidate.ranking_score.max(0.0))
+    let mut ranked = rank_standard_split_choices(
+        context,
+        rows,
+        depth,
+        &current_class_counts,
+        &split_candidates,
+        &feature_indices,
+        lookahead_depth,
+    );
+    ranked.sort_by(|left, right| right.ranking_score.total_cmp(&left.ranking_score));
+    ranked
+        .into_iter()
+        .take(beam_width.max(1))
+        .map(|candidate| candidate.ranking_score.max(0.0))
+        .fold(0.0, f64::max)
 }
 
 fn collect_oblique_classification_candidates(
@@ -1787,6 +1800,7 @@ fn multiway_split_ranking_score(
                 depth + 1,
                 metric,
                 lookahead_depth - 1,
+                context.options.effective_beam_width(),
             )
         })
         .sum::<f64>();
@@ -1799,6 +1813,7 @@ fn best_multiway_split_lookahead_score(
     depth: usize,
     metric: MultiwayMetric,
     lookahead_depth: usize,
+    beam_width: usize,
 ) -> f64 {
     if rows.is_empty()
         || lookahead_depth == 0
@@ -1828,15 +1843,13 @@ fn best_multiway_split_lookahead_score(
             score_multiway_split_choice(&scoring, feature_index, rows, metric)
         })
         .collect::<Vec<_>>();
-    select_best_non_canary_candidate(
-        context.table,
-        rank_multiway_split_choices(context, rows, depth, metric, split_candidates),
-        context.options.canary_filter,
-        |candidate| candidate.ranking_score,
-        |candidate| candidate.choice.feature_index,
-    )
-    .selected
-    .map_or(0.0, |candidate| candidate.ranking_score.max(0.0))
+    let mut ranked = rank_multiway_split_choices(context, rows, depth, metric, split_candidates);
+    ranked.sort_by(|left, right| right.ranking_score.total_cmp(&left.ranking_score));
+    ranked
+        .into_iter()
+        .take(beam_width.max(1))
+        .map(|candidate| candidate.ranking_score.max(0.0))
+        .fold(0.0, f64::max)
 }
 
 fn rank_shortlisted_candidates(

--- a/crates/core/src/tree/classifier/oblivious.rs
+++ b/crates/core/src/tree/classifier/oblivious.rs
@@ -473,6 +473,7 @@ fn oblivious_split_ranking_score(
         options,
         depth + 1,
         lookahead_depth - 1,
+        options.effective_beam_width(),
     );
     immediate + options.lookahead_weight * future
 }
@@ -488,6 +489,7 @@ fn best_oblivious_split_lookahead_score(
     options: &DecisionTreeOptions,
     depth: usize,
     lookahead_depth: usize,
+    beam_width: usize,
 ) -> f64 {
     if leaves
         .iter()
@@ -518,32 +520,30 @@ fn best_oblivious_split_lookahead_score(
             )
         })
         .collect::<Vec<_>>();
-    select_best_non_canary_candidate(
-        table,
-        rank_shortlisted_oblivious_candidates(
-            split_candidates,
-            options.lookahead_top_k,
-            |candidate| {
-                oblivious_split_ranking_score(
-                    table,
-                    row_indices,
-                    class_indices,
-                    num_classes,
-                    &leaves,
-                    criterion,
-                    options,
-                    depth,
-                    candidate,
-                    lookahead_depth,
-                )
-            },
-        ),
-        options.canary_filter,
-        |candidate| candidate.ranking_score,
-        |candidate| candidate.candidate.feature_index,
-    )
-    .selected
-    .map_or(0.0, |candidate| candidate.ranking_score.max(0.0))
+    let mut ranked = rank_shortlisted_oblivious_candidates(
+        split_candidates,
+        options.lookahead_top_k,
+        |candidate| {
+            oblivious_split_ranking_score(
+                table,
+                row_indices,
+                class_indices,
+                num_classes,
+                &leaves,
+                criterion,
+                options,
+                depth,
+                candidate,
+                lookahead_depth,
+            )
+        },
+    );
+    ranked.sort_by(|left, right| right.ranking_score.total_cmp(&left.ranking_score));
+    ranked
+        .into_iter()
+        .take(beam_width.max(1))
+        .map(|candidate| candidate.ranking_score.max(0.0))
+        .fold(0.0, f64::max)
 }
 
 fn rank_shortlisted_oblivious_candidates(

--- a/crates/core/src/tree/regressor.rs
+++ b/crates/core/src/tree/regressor.rs
@@ -52,6 +52,7 @@ pub struct RegressionTreeOptions {
     pub lookahead_depth: usize,
     pub lookahead_top_k: usize,
     pub lookahead_weight: f64,
+    pub beam_width: usize,
 }
 
 impl Default for RegressionTreeOptions {
@@ -69,6 +70,7 @@ impl Default for RegressionTreeOptions {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
         }
     }
 }
@@ -77,7 +79,14 @@ impl RegressionTreeOptions {
     pub(crate) fn effective_lookahead_depth(&self) -> usize {
         match self.builder {
             BuilderStrategy::Greedy => 1,
-            BuilderStrategy::Lookahead => self.lookahead_depth,
+            BuilderStrategy::Lookahead | BuilderStrategy::Beam => self.lookahead_depth,
+        }
+    }
+
+    pub(crate) fn effective_beam_width(&self) -> usize {
+        match self.builder {
+            BuilderStrategy::Greedy | BuilderStrategy::Lookahead => 1,
+            BuilderStrategy::Beam => self.beam_width,
         }
     }
 
@@ -1256,14 +1265,19 @@ fn standard_split_ranking_score(
         ),
     };
     let (left_rows, right_rows) = partitioned_rows.split_at_mut(left_count);
-    let future =
-        best_standard_split_lookahead_score(context, left_rows, depth + 1, lookahead_depth - 1)
-            + best_standard_split_lookahead_score(
-                context,
-                right_rows,
-                depth + 1,
-                lookahead_depth - 1,
-            );
+    let future = best_standard_split_lookahead_score(
+        context,
+        left_rows,
+        depth + 1,
+        lookahead_depth - 1,
+        context.options.effective_beam_width(),
+    ) + best_standard_split_lookahead_score(
+        context,
+        right_rows,
+        depth + 1,
+        lookahead_depth - 1,
+        context.options.effective_beam_width(),
+    );
     immediate + context.options.lookahead_weight * future
 }
 
@@ -1272,6 +1286,7 @@ fn best_standard_split_lookahead_score(
     rows: &mut [usize],
     depth: usize,
     lookahead_depth: usize,
+    beam_width: usize,
 ) -> f64 {
     if rows.is_empty()
         || lookahead_depth == 0
@@ -1311,22 +1326,20 @@ fn best_standard_split_lookahead_score(
             }
         })
         .collect::<Vec<_>>();
-    select_best_non_canary_candidate(
-        context.table,
-        rank_standard_split_choices(
-            context,
-            rows,
-            depth,
-            &split_candidates,
-            &feature_indices,
-            lookahead_depth,
-        ),
-        context.options.canary_filter,
-        |candidate| candidate.ranking_score,
-        |candidate| candidate.choice.ranking_feature_index(),
-    )
-    .selected
-    .map_or(0.0, |candidate| candidate.ranking_score.max(0.0))
+    let mut ranked = rank_standard_split_choices(
+        context,
+        rows,
+        depth,
+        &split_candidates,
+        &feature_indices,
+        lookahead_depth,
+    );
+    ranked.sort_by(|left, right| right.ranking_score.total_cmp(&left.ranking_score));
+    ranked
+        .into_iter()
+        .take(beam_width.max(1))
+        .map(|candidate| candidate.ranking_score.max(0.0))
+        .fold(0.0, f64::max)
 }
 
 fn rank_shortlisted_candidates(
@@ -1919,6 +1932,7 @@ fn oblivious_split_ranking_score(
         options,
         depth + 1,
         lookahead_depth - 1,
+        options.effective_beam_width(),
     );
     immediate + options.lookahead_weight * future
 }
@@ -1933,6 +1947,7 @@ fn best_oblivious_split_lookahead_score(
     options: &RegressionTreeOptions,
     depth: usize,
     lookahead_depth: usize,
+    beam_width: usize,
 ) -> f64 {
     if leaves
         .iter()
@@ -1962,31 +1977,29 @@ fn best_oblivious_split_lookahead_score(
             )
         })
         .collect::<Vec<_>>();
-    select_best_non_canary_candidate(
-        table,
-        rank_shortlisted_oblivious_candidates(
-            split_candidates,
-            options.lookahead_top_k,
-            |candidate| {
-                oblivious_split_ranking_score(
-                    table,
-                    row_indices,
-                    targets,
-                    &leaves,
-                    criterion,
-                    options,
-                    depth,
-                    candidate,
-                    lookahead_depth,
-                )
-            },
-        ),
-        options.canary_filter,
-        |candidate| candidate.ranking_score,
-        |candidate| candidate.candidate.feature_index,
-    )
-    .selected
-    .map_or(0.0, |candidate| candidate.ranking_score.max(0.0))
+    let mut ranked = rank_shortlisted_oblivious_candidates(
+        split_candidates,
+        options.lookahead_top_k,
+        |candidate| {
+            oblivious_split_ranking_score(
+                table,
+                row_indices,
+                targets,
+                &leaves,
+                criterion,
+                options,
+                depth,
+                candidate,
+                lookahead_depth,
+            )
+        },
+    );
+    ranked.sort_by(|left, right| right.ranking_score.total_cmp(&left.ranking_score));
+    ranked
+        .into_iter()
+        .take(beam_width.max(1))
+        .map(|candidate| candidate.ranking_score.max(0.0))
+        .fold(0.0, f64::max)
 }
 
 fn rank_shortlisted_oblivious_candidates(

--- a/crates/core/src/tree/second_order.rs
+++ b/crates/core/src/tree/second_order.rs
@@ -1186,14 +1186,19 @@ fn standard_split_ranking_score(
         ),
     };
     let (left_rows, right_rows) = partitioned_rows.split_at_mut(left_count);
-    let future =
-        best_standard_split_lookahead_score(context, left_rows, depth + 1, lookahead_depth - 1)
-            + best_standard_split_lookahead_score(
-                context,
-                right_rows,
-                depth + 1,
-                lookahead_depth - 1,
-            );
+    let future = best_standard_split_lookahead_score(
+        context,
+        left_rows,
+        depth + 1,
+        lookahead_depth - 1,
+        context.options.tree_options.effective_beam_width(),
+    ) + best_standard_split_lookahead_score(
+        context,
+        right_rows,
+        depth + 1,
+        lookahead_depth - 1,
+        context.options.tree_options.effective_beam_width(),
+    );
     immediate + context.options.tree_options.lookahead_weight * future
 }
 
@@ -1202,6 +1207,7 @@ fn best_standard_split_lookahead_score(
     rows: &mut [usize],
     depth: usize,
     lookahead_depth: usize,
+    beam_width: usize,
 ) -> f64 {
     if rows.is_empty()
         || lookahead_depth == 0
@@ -1238,22 +1244,20 @@ fn best_standard_split_lookahead_score(
             score_feature_from_hist(context, &histograms[*feature_index], *feature_index, rows)
         })
         .collect::<Vec<_>>();
-    select_best_non_canary_candidate(
-        context.table,
-        rank_standard_split_choices(
-            context,
-            rows,
-            depth,
-            &split_candidates,
-            &feature_indices,
-            lookahead_depth,
-        ),
-        context.options.tree_options.canary_filter,
-        |candidate| candidate.ranking_score,
-        |candidate| candidate.choice.ranking_feature_index(),
-    )
-    .selected
-    .map_or(0.0, |candidate| candidate.ranking_score.max(0.0))
+    let mut ranked = rank_standard_split_choices(
+        context,
+        rows,
+        depth,
+        &split_candidates,
+        &feature_indices,
+        lookahead_depth,
+    );
+    ranked.sort_by(|left, right| right.ranking_score.total_cmp(&left.ranking_score));
+    ranked
+        .into_iter()
+        .take(beam_width.max(1))
+        .map(|candidate| candidate.ranking_score.max(0.0))
+        .fold(0.0, f64::max)
 }
 
 fn rank_shortlisted_candidates(
@@ -1954,6 +1958,7 @@ fn oblivious_split_ranking_score(
         options,
         depth + 1,
         lookahead_depth - 1,
+        options.tree_options.effective_beam_width(),
     );
     immediate + options.tree_options.lookahead_weight * future
 }
@@ -1968,6 +1973,7 @@ fn best_oblivious_split_lookahead_score(
     options: &SecondOrderRegressionTreeOptions,
     depth: usize,
     lookahead_depth: usize,
+    beam_width: usize,
 ) -> f64 {
     if leaves
         .iter()
@@ -1997,31 +2003,29 @@ fn best_oblivious_split_lookahead_score(
             )
         })
         .collect::<Vec<_>>();
-    select_best_non_canary_candidate(
-        table,
-        rank_shortlisted_oblivious_candidates(
-            split_candidates,
-            options.tree_options.lookahead_top_k,
-            |candidate| {
-                oblivious_split_ranking_score(
-                    table,
-                    row_indices,
-                    gradients,
-                    hessians,
-                    &leaves,
-                    options,
-                    depth,
-                    candidate,
-                    lookahead_depth,
-                )
-            },
-        ),
-        options.tree_options.canary_filter,
-        |candidate| candidate.ranking_score,
-        |candidate| candidate.choice.feature_index,
-    )
-    .selected
-    .map_or(0.0, |candidate| candidate.ranking_score.max(0.0))
+    let mut ranked = rank_shortlisted_oblivious_candidates(
+        split_candidates,
+        options.tree_options.lookahead_top_k,
+        |candidate| {
+            oblivious_split_ranking_score(
+                table,
+                row_indices,
+                gradients,
+                hessians,
+                &leaves,
+                options,
+                depth,
+                candidate,
+                lookahead_depth,
+            )
+        },
+    );
+    ranked.sort_by(|left, right| right.ranking_score.total_cmp(&left.ranking_score));
+    ranked
+        .into_iter()
+        .take(beam_width.max(1))
+        .map(|candidate| candidate.ranking_score.max(0.0))
+        .fold(0.0, f64::max)
 }
 
 fn rank_shortlisted_oblivious_candidates(

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forestfire-data"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/wsperat/forest-fire"

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "forestfire-inference"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/wsperat/forest-fire"
 description = "Inference-facing traits and helpers for ForestFire models."
 
 [dependencies]
-forestfire-core = { version = "0.5.1", path = "../core" }
-forestfire-data = { version = "0.5.1", path = "../data" }
+forestfire-core = { version = "0.5.2", path = "../core" }
+forestfire-data = { version = "0.5.2", path = "../data" }
 arrow.workspace = true

--- a/docs/beam-builder.md
+++ b/docs/beam-builder.md
@@ -1,0 +1,156 @@
+# Beam Builder
+
+The beam builder extends the lookahead idea by keeping several strong future
+continuations alive instead of following only one.
+
+This makes it a middle ground between:
+
+- `builder="greedy"`: immediate score only
+- `builder="lookahead"`: immediate score plus one best continuation
+- `builder="beam"`: immediate score plus a width-limited continuation search
+
+## Public API
+
+Python:
+
+```python
+train(
+    X,
+    y,
+    builder="beam",
+    lookahead_depth=2,
+    lookahead_top_k=8,
+    lookahead_weight=0.5,
+    beam_width=4,
+)
+```
+
+Rust:
+
+```rust
+use forestfire_core::{BuilderStrategy, TrainConfig};
+
+let config = TrainConfig {
+    builder: BuilderStrategy::Beam,
+    lookahead_depth: 2,
+    lookahead_top_k: 8,
+    lookahead_weight: 0.5,
+    beam_width: 4,
+    ..TrainConfig::default()
+};
+```
+
+## Parameters
+
+- `builder="beam"` enables width-limited continuation search.
+- `lookahead_depth` controls how many future levels are considered.
+- `lookahead_top_k` limits which immediate candidates are eligible for
+  continuation rescoring.
+- `lookahead_weight` controls how strongly future score influences ranking.
+- `beam_width` controls how many descendant continuations stay alive at each
+  future rescoring step.
+
+The current ranking model is still:
+
+```text
+ranking_score = immediate_gain + lookahead_weight * future_gain
+```
+
+What changes relative to plain lookahead is how `future_gain` is estimated.
+
+## How it works
+
+At the current node:
+
+1. score all candidates by immediate gain
+2. keep the top `lookahead_top_k`
+3. partition rows for each shortlisted candidate
+4. score the next level recursively
+5. at each future step, keep the top `beam_width` ranked continuations alive
+6. use the strongest surviving continuation score as the candidate's
+   `future_gain`
+7. choose the final winner after normal canary filtering
+
+So the current implementation is a width-limited continuation search layered on
+top of local split ranking. It is not yet a full global beam search over whole
+partial-tree states.
+
+That distinction matters:
+
+- the beam builder improves local split choice
+- it does not yet optimize the entire tree jointly
+- it remains compatible with the existing tree-construction code paths
+
+## Missing values
+
+Like the lookahead builder, the beam builder uses the learner’s existing
+missing-value semantics during future rescoring.
+
+That means the simulated continuation search respects:
+
+- learned missing routing for axis-aligned splits
+- per-feature missing directions for oblique splits
+- multiway missing handling for `id3` and `c45`
+- current second-order GBM missing routing
+
+The future score is therefore based on the same partition behavior the final
+tree would use if that candidate wins.
+
+## Support matrix
+
+`builder="beam"` is exposed anywhere the corresponding learner family is
+currently supported:
+
+- decision trees
+- random forests
+- gradient boosting
+
+and across the current tree-family surface:
+
+- `id3`
+- `c45`
+- `cart`
+- `randomized`
+- `oblivious`
+
+Split-strategy support still applies independently. In particular, oblique
+splits remain limited to the tree families that already support
+`split_strategy="oblique"`.
+
+## Tradeoffs
+
+Why use it:
+
+- it is less short-sighted than greedy scoring
+- it is more robust than single-path lookahead when several future continuations
+  look plausible
+- it can recover from locally ambiguous node choices better than plain
+  lookahead
+
+Costs:
+
+- slower than both `greedy` and `lookahead`
+- higher memory and ranking overhead during rescoring
+- wide beams can spend effort preserving branches that do not ultimately matter
+
+Reasonable first settings:
+
+- `lookahead_depth=2`
+- `lookahead_top_k=4` or `8`
+- `lookahead_weight=0.25` to `0.75`
+- `beam_width=2` or `4`
+
+## When to use beam over lookahead
+
+Prefer `beam` when:
+
+- the node has several similarly strong immediate splits
+- you suspect the best split is only obvious after more than one plausible
+  continuation is explored
+- you can afford extra training time
+
+Prefer `lookahead` when:
+
+- you want a cheaper upgrade over greedy search
+- training cost matters more than squeezing out a better local choice
+- the data usually has one clearly dominant continuation anyway

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -357,6 +357,214 @@ What this example shows:
   because oblique nodes can cover two features in one split, and the winning
   competition may leave different features unused
 
+## Example 5: Missing-value routing and optimized inference
+
+This example shows the training-side missing-value strategies and the runtime
+side `missing_features` optimization knob.
+
+```python
+import numpy as np
+
+from forestfire import train
+
+X = np.array(
+    [
+        [0.0, np.nan, 1.0],
+        [0.0, 0.0, 1.0],
+        [1.0, np.nan, 0.0],
+        [1.0, 1.0, 0.0],
+        [0.0, 1.0, 1.0],
+        [1.0, 0.0, 0.0],
+    ]
+)
+y = np.array([0.0, 0.0, 1.0, 1.0, 0.0, 1.0])
+
+heuristic = train(
+    X,
+    y,
+    task="classification",
+    tree_type="cart",
+    missing_value_strategy="heuristic",
+)
+
+optimal = train(
+    X,
+    y,
+    task="classification",
+    tree_type="cart",
+    missing_value_strategy={"f0": "heuristic", "f1": "optimal", "f2": "heuristic"},
+)
+
+batch = X[:4]
+
+base_pred = optimal.predict_proba(batch)
+optimized_all_missing = optimal.optimize_inference()
+optimized_only_f1_missing = optimal.optimize_inference(missing_features=[1])
+
+print(np.allclose(base_pred, optimized_all_missing.predict_proba(batch)))
+print(np.allclose(base_pred, optimized_only_f1_missing.predict_proba(batch)))
+print(heuristic.tree_structure())
+print(optimal.tree_structure())
+```
+
+What this example shows:
+
+- missing-value behavior is part of training, not a preprocessing afterthought
+- `missing_value_strategy` can be global or per feature
+- optimized inference preserves the learned missing routing
+- `missing_features=[...]` is only a runtime promise about which columns may be
+  missing later; it does not retrain the model
+
+## Example 6: Native categorical strategies
+
+This example uses raw string categories directly and compares the three exposed
+categorical strategies.
+
+```python
+import numpy as np
+
+from forestfire import Model, train
+
+X = [
+    ["red", "small", 1.2],
+    ["red", "large", 0.7],
+    ["blue", "small", 2.4],
+    ["blue", "large", 2.0],
+    ["green", "small", 0.4],
+    ["green", "large", 0.2],
+    ["red", "small", 1.0],
+    ["blue", "large", 2.3],
+]
+y = np.array([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0])
+
+for strategy in ["dummy", "target", "fisher"]:
+    model = train(
+        X,
+        y,
+        task="classification",
+        tree_type="cart",
+        categorical_strategy=strategy,
+        categorical_features=[0, 1],
+        target_smoothing=20.0,
+    )
+
+    pred = model.predict(X)
+    payload = model.serialize()
+    reloaded = Model.deserialize(payload)
+
+    print(strategy, pred[:4], np.allclose(pred, reloaded.predict(X)))
+```
+
+What this example shows:
+
+- Python sends raw categorical values directly to the native Rust path
+- `dummy`, `target`, and `fisher` all fit through the same `train(...)` API
+- categorical transform state is preserved in serialization and reload
+- `target_smoothing` is the base regularization control for `target` and
+  Fisher-style ordering
+
+## Example 7: Greedy vs lookahead vs beam builders
+
+This example compares the three builder strategies on the same training task.
+
+```python
+import numpy as np
+
+from forestfire import train
+
+rng = np.random.default_rng(31)
+X = rng.normal(size=(10_000, 6))
+y = (
+    ((X[:, 0] > 0.5) & (X[:, 1] < -0.1))
+    | ((X[:, 2] + X[:, 3]) > 0.6)
+    | ((X[:, 4] - X[:, 5]) > 1.0)
+).astype(float)
+
+greedy = train(
+    X,
+    y,
+    task="classification",
+    tree_type="cart",
+    builder="greedy",
+)
+
+lookahead = train(
+    X,
+    y,
+    task="classification",
+    tree_type="cart",
+    builder="lookahead",
+    lookahead_depth=2,
+    lookahead_top_k=4,
+    lookahead_weight=0.5,
+)
+
+beam = train(
+    X,
+    y,
+    task="classification",
+    tree_type="cart",
+    builder="beam",
+    lookahead_depth=2,
+    lookahead_top_k=4,
+    lookahead_weight=0.5,
+    beam_width=2,
+)
+
+for label, model in [("greedy", greedy), ("lookahead", lookahead), ("beam", beam)]:
+    print(label)
+    print(model.tree_structure())
+```
+
+What this example shows:
+
+- builder strategy is independent from tree family and split family
+- `lookahead` and `beam` reuse the same public depth and weighting knobs
+- `beam_width` only matters for `builder="beam"`
+- all three builders still produce ordinary semantic models that support the
+  same introspection, optimization, and serialization flow
+
+## Example 8: Oblique splits with beam search
+
+This example combines two newer features: oblique split search and the beam
+builder.
+
+```python
+import numpy as np
+
+from forestfire import train
+
+rng = np.random.default_rng(9)
+X = rng.normal(size=(12_000, 6))
+y = ((0.8 * X[:, 0] - 1.1 * X[:, 1]) + (0.6 * X[:, 2] + 0.4 * X[:, 3]) > 0.3).astype(float)
+
+model = train(
+    X,
+    y,
+    algorithm="dt",
+    task="classification",
+    tree_type="randomized",
+    split_strategy="oblique",
+    builder="beam",
+    lookahead_depth=2,
+    lookahead_top_k=6,
+    lookahead_weight=0.5,
+    beam_width=3,
+    canaries=2,
+    filter=0.95,
+)
+
+print(model.tree_structure())
+print(model.tree_node(node_id=0, tree_index=0))
+```
+
+What this example shows:
+
+- oblique splits and builder strategy are orthogonal controls
+- canary competition still applies when oblique candidates are in the pool
+- beam search can be used on top of the same CART/randomized families that
+  already support oblique split search
+
 ## Why these examples matter
 
 ForestFire is not only a trainer and not only an inference runtime.

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,9 @@ ForestFire is intentionally opinionated in a few places:
 - [Rust API](rust-api.md): Rust crates and training entrypoints
 - [Examples](examples.md): end-to-end workflows from training through reload and batch scoring
 - [Training](training.md): algorithms, parameters, and stopping behavior
+- Builders:
+  - [Lookahead Builder](lookahead-builder.md): shortlist-based future-aware split ranking
+  - [Beam Builder](beam-builder.md): width-limited continuation search for split ranking
 - [Categorical Strategies](categorical-strategies.md): `dummy`, `target`, and `fisher` categorical handling through the native training API
 - [Oblique Splits](oblique-splits.md): pairwise linear splits, weight computation, candidate competition, and when to use them
 - [Models And Introspection](models.md): prediction, optimization, serialization, and tree inspection

--- a/docs/lookahead-builder.md
+++ b/docs/lookahead-builder.md
@@ -1,0 +1,141 @@
+# Lookahead Builder
+
+The lookahead builder is an alternative to the default greedy tree-construction
+path.
+
+With the greedy builder, a node picks the split with the best immediate score at
+that node and commits to it immediately.
+
+With the lookahead builder, a node still starts from immediate scores, but it
+re-ranks a shortlisted set of candidates by estimating how much useful structure
+they expose in their children.
+
+## Public API
+
+Python:
+
+```python
+train(
+    X,
+    y,
+    builder="lookahead",
+    lookahead_depth=2,
+    lookahead_top_k=8,
+    lookahead_weight=0.5,
+)
+```
+
+Rust:
+
+```rust
+use forestfire_core::{BuilderStrategy, TrainConfig};
+
+let config = TrainConfig {
+    builder: BuilderStrategy::Lookahead,
+    lookahead_depth: 2,
+    lookahead_top_k: 8,
+    lookahead_weight: 0.5,
+    ..TrainConfig::default()
+};
+```
+
+## Parameters
+
+- `builder="lookahead"` enables the lookahead ranking path.
+- `lookahead_depth` controls how many additional levels are explored while
+  scoring a candidate split.
+- `lookahead_top_k` limits how many immediate candidates are eligible for
+  lookahead rescoring.
+- `lookahead_weight` controls how strongly future score affects the final
+  ranking.
+
+The effective ranking is:
+
+```text
+ranking_score = immediate_gain + lookahead_weight * future_gain
+```
+
+If `lookahead_depth <= 1`, the behavior collapses back to greedy ranking.
+
+## How it works
+
+At each node:
+
+1. score all legal split candidates by immediate gain
+2. sort them by that immediate score
+3. keep only the top `lookahead_top_k`
+4. for each shortlisted candidate, simulate the child partitions
+5. score the best child continuation recursively up to `lookahead_depth`
+6. combine immediate and future score into one ranking value
+7. choose the highest-ranked real split after canary filtering
+
+This means the builder is still fundamentally local: it does not optimize the
+whole tree jointly. What changes is the scoring rule for a candidate split at
+the current node.
+
+## Missing values
+
+Lookahead does not invent a separate missing-value policy. It uses the exact
+missing-value behavior of the underlying learner while simulating the future
+partitions.
+
+That means:
+
+- axis-aligned trees reuse their learned missing-branch routing
+- oblique trees reuse their per-feature missing directions
+- ID3/C4.5 reuse their multiway missing routing
+- second-order GBM trees reuse their current missing-routing semantics during
+  lookahead scoring
+
+This is important because the rescoring pass should evaluate the same routing
+behavior that the final built tree will actually use.
+
+## Support matrix
+
+`builder="lookahead"` is available anywhere the corresponding learner family is
+already supported:
+
+- decision trees
+- random forests
+- gradient boosting
+
+and across the currently exposed tree families:
+
+- `id3`
+- `c45`
+- `cart`
+- `randomized`
+- `oblivious`
+
+The actual split family limits still apply independently. For example, oblique
+splits remain restricted to the tree families that already support
+`split_strategy="oblique"`.
+
+## Tradeoffs
+
+Why use it:
+
+- it can avoid short-sighted splits that look good locally but isolate weak
+  child structure
+- it is a better fit for data where useful signal appears only after one more
+  split
+
+Costs:
+
+- training is slower than `builder="greedy"`
+- candidate rescoring allocates more work per node
+- deeper lookahead horizons can amplify noise if `lookahead_weight` is too high
+
+Reasonable first settings:
+
+- `lookahead_depth=2`
+- `lookahead_top_k=4` or `8`
+- `lookahead_weight=0.25` to `0.75`
+
+## Relationship to beam search
+
+The lookahead builder follows only the single best continuation at each future
+step.
+
+If you want to keep multiple strong continuations alive during rescoring, use
+the [Beam Builder](beam-builder.md) instead.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -18,6 +18,11 @@ train(
     task="auto",
     tree_type="cart",
     split_strategy="axis_aligned",
+    builder="greedy",
+    lookahead_depth=1,
+    lookahead_top_k=8,
+    lookahead_weight=1.0,
+    beam_width=4,
     criterion="auto",
     canaries=2,
     bins="auto",
@@ -48,6 +53,7 @@ train(
 - `task="auto" | "regression" | "classification"`
 - `tree_type="id3" | "c45" | "cart" | "randomized" | "oblivious"`
 - `split_strategy="axis_aligned" | "oblique"`
+- `builder="greedy" | "lookahead" | "beam"`
 - `criterion="auto" | "gini" | "entropy" | "mean" | "median"`
 
 ### Parameter semantics
@@ -99,6 +105,32 @@ Current `auto` behavior:
 - classification `cart`, `randomized`, `oblivious` -> `gini`
 - regression models -> `mean`
 - `gbm` trains second-order trees internally when `criterion="auto"`
+
+#### `builder`
+
+- `greedy`: ordinary immediate-gain split ranking
+- `lookahead`: re-rank the top immediate candidates by one-best-continuation
+  future score
+- `beam`: re-rank the top immediate candidates by width-limited continuation
+  search
+
+Builder controls tree construction strategy independently of:
+
+- `algorithm`
+- `tree_type`
+- `split_strategy`
+
+Related parameters:
+
+- `lookahead_depth`
+- `lookahead_top_k`
+- `lookahead_weight`
+- `beam_width`
+
+For the detailed behavior, see:
+
+- [Lookahead Builder](lookahead-builder.md)
+- [Beam Builder](beam-builder.md)
 
 #### `canaries`
 

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -35,6 +35,7 @@ The intended Rust lifecycle is:
 - `Task`
 - `TreeType`
 - `SplitStrategy`
+- `BuilderStrategy`
 - `Criterion`
 - `Model`
 - `OptimizedModel`
@@ -48,6 +49,22 @@ Current support:
 
 - `AxisAligned`: all supported tree families
 - `Oblique`: `dt`, `rf`, and `gbm` when `tree_type` is `Cart` or `Randomized`
+
+`TrainConfig::builder` selects the tree-construction strategy:
+
+- `BuilderStrategy::Greedy`
+- `BuilderStrategy::Lookahead`
+- `BuilderStrategy::Beam`
+
+Related `TrainConfig` fields:
+
+- `lookahead_depth`
+- `lookahead_top_k`
+- `lookahead_weight`
+- `beam_width`
+
+Those control how split candidates are ranked during tree growth, not which
+split family is available.
 
 ## Core capabilities
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -83,6 +83,42 @@ Current implementation details:
 - all candidate feature pairs available at a node are considered
 - axis-aligned and oblique candidates compete inside the same canary-filtered ranking
 
+## Builders
+
+ForestFire also separates tree family from tree-construction strategy.
+
+The public builders are:
+
+- `greedy`
+- `lookahead`
+- `beam`
+
+At a high level:
+
+- `greedy` ranks candidates by immediate node-local score only
+- `lookahead` shortlists the strongest immediate candidates and re-ranks them by
+  following the single best continuation up to `lookahead_depth`
+- `beam` uses the same shortlist idea, but keeps up to `beam_width`
+  continuations alive while estimating future score
+
+The builder controls how a node decides which split to take. It does not change:
+
+- the split family itself
+- the missing-value semantics of the learner
+- the leaf payload semantics
+
+Related parameters:
+
+- `lookahead_depth`
+- `lookahead_top_k`
+- `lookahead_weight`
+- `beam_width`
+
+For the detailed algorithmic behavior, see:
+
+- [Lookahead Builder](lookahead-builder.md)
+- [Beam Builder](beam-builder.md)
+
 ## Task detection
 
 With `task="auto"`:

--- a/examples/python/showcase.py
+++ b/examples/python/showcase.py
@@ -190,6 +190,139 @@ def show_canary_filter_policy() -> None:
     print("top_5pct root ->", top_5_percent.tree_structure())
 
 
+def show_oblique_models() -> None:
+    rng = np.random.default_rng(7)
+    x = rng.normal(size=(6_000, 6))
+    y = (x[:, 0] + x[:, 1] > 0.5).astype(float)
+
+    axis_model = train(
+        x,
+        y,
+        algorithm="dt",
+        task="classification",
+        tree_type="cart",
+        split_strategy="axis_aligned",
+        canaries=2,
+    )
+    oblique_model = train(
+        x,
+        y,
+        algorithm="dt",
+        task="classification",
+        tree_type="cart",
+        split_strategy="oblique",
+        canaries=2,
+    )
+    optimized = oblique_model.optimize_inference(physical_cores=1)
+
+    print_section("Oblique Splits")
+    print("axis root     ->", axis_model.tree_node(0, tree_index=0))
+    print("oblique root  ->", oblique_model.tree_node(0, tree_index=0))
+    print("optimized pred->", optimized.predict_proba(x[:4]).tolist())
+
+
+def show_builder_strategies() -> None:
+    rng = np.random.default_rng(31)
+    x = rng.normal(size=(8_000, 6))
+    y = (
+        ((x[:, 0] > 0.5) & (x[:, 1] < -0.1))
+        | ((x[:, 2] + x[:, 3]) > 0.6)
+        | ((x[:, 4] - x[:, 5]) > 1.0)
+    ).astype(float)
+
+    configs = [
+        ("greedy", {}),
+        (
+            "lookahead",
+            {"lookahead_depth": 2, "lookahead_top_k": 4, "lookahead_weight": 0.5},
+        ),
+        (
+            "beam",
+            {
+                "lookahead_depth": 2,
+                "lookahead_top_k": 4,
+                "lookahead_weight": 0.5,
+                "beam_width": 2,
+            },
+        ),
+    ]
+
+    print_section("Builder Strategies")
+    for builder, extra in configs:
+        model = train(
+            x,
+            y,
+            task="classification",
+            tree_type="cart",
+            builder=builder,
+            canaries=0,
+            **extra,
+        )
+        print(f"{builder:>9} ->", model.tree_structure())
+
+
+def show_missing_value_routing() -> None:
+    x = np.array(
+        [
+            [0.0, np.nan, 1.0],
+            [0.0, 0.0, 1.0],
+            [1.0, np.nan, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0],
+            [1.0, 0.0, 0.0],
+        ]
+    )
+    y = np.array([0.0, 0.0, 1.0, 1.0, 0.0, 1.0], dtype=float)
+
+    heuristic = train(
+        x,
+        y,
+        task="classification",
+        tree_type="cart",
+        missing_value_strategy="heuristic",
+    )
+    optimal = train(
+        x,
+        y,
+        task="classification",
+        tree_type="cart",
+        missing_value_strategy={"f0": "heuristic", "f1": "optimal", "f2": "heuristic"},
+    )
+    optimized = optimal.optimize_inference(physical_cores=1, missing_features=[1])
+
+    print_section("Missing Value Routing")
+    print("heuristic root->", heuristic.tree_node(0, tree_index=0))
+    print("optimal root  ->", optimal.tree_node(0, tree_index=0))
+    print("optimized pred->", optimized.predict_proba(x[:4]).tolist())
+
+
+def show_categorical_strategies() -> None:
+    x = [
+        ["red", "small", 1.2],
+        ["red", "large", 0.7],
+        ["blue", "small", 2.4],
+        ["blue", "large", 2.0],
+        ["green", "small", 0.4],
+        ["green", "large", 0.2],
+        ["red", "small", 1.0],
+        ["blue", "large", 2.3],
+    ]
+    y = np.array([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0], dtype=float)
+
+    print_section("Categorical Strategies")
+    for strategy in ("dummy", "target", "fisher"):
+        model = train(
+            x,
+            y,
+            task="classification",
+            tree_type="cart",
+            categorical_strategy=strategy,
+            categorical_features=[0, 1],
+            target_smoothing=20.0,
+        )
+        print(f"{strategy:>8} ->", model.predict(x).tolist())
+
+
 def show_serialization() -> None:
     x, y = regression_rows()
     model = train(x, y, task="regression", tree_type="cart", canaries=0, bins="auto")
@@ -240,6 +373,10 @@ def main() -> None:
     show_training_tables()
     show_inference_inputs_and_optimized_runtime()
     show_canary_filter_policy()
+    show_oblique_models()
+    show_builder_strategies()
+    show_missing_value_routing()
+    show_categorical_strategies()
     show_serialization()
     show_optional_sparse_input()
 

--- a/examples/python/showcase.py
+++ b/examples/python/showcase.py
@@ -230,34 +230,44 @@ def show_builder_strategies() -> None:
         | ((x[:, 4] - x[:, 5]) > 1.0)
     ).astype(float)
 
-    configs = [
-        ("greedy", {}),
-        (
-            "lookahead",
-            {"lookahead_depth": 2, "lookahead_top_k": 4, "lookahead_weight": 0.5},
-        ),
-        (
-            "beam",
-            {
-                "lookahead_depth": 2,
-                "lookahead_top_k": 4,
-                "lookahead_weight": 0.5,
-                "beam_width": 2,
-            },
-        ),
-    ]
-
     print_section("Builder Strategies")
-    for builder, extra in configs:
-        model = train(
-            x,
-            y,
-            task="classification",
-            tree_type="cart",
-            builder=builder,
-            canaries=0,
-            **extra,
-        )
+    greedy = train(
+        x,
+        y,
+        task="classification",
+        tree_type="cart",
+        builder="greedy",
+        canaries=0,
+    )
+    lookahead = train(
+        x,
+        y,
+        task="classification",
+        tree_type="cart",
+        builder="lookahead",
+        lookahead_depth=2,
+        lookahead_top_k=4,
+        lookahead_weight=0.5,
+        canaries=0,
+    )
+    beam = train(
+        x,
+        y,
+        task="classification",
+        tree_type="cart",
+        builder="beam",
+        lookahead_depth=2,
+        lookahead_top_k=4,
+        lookahead_weight=0.5,
+        beam_width=2,
+        canaries=0,
+    )
+
+    for builder, model in (
+        ("greedy", greedy),
+        ("lookahead", lookahead),
+        ("beam", beam),
+    ):
         print(f"{builder:>9} ->", model.tree_structure())
 
 

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/wsperat/forest-fire"
 description = "Runnable Rust examples for the ForestFire project."
 
 [dependencies]
-forestfire-core = { version = "0.5.1", path = "../../crates/core" }
-forestfire-data = { version = "0.5.1", path = "../../crates/data" }
+forestfire-core = { version = "0.5.2", path = "../../crates/core" }
+forestfire-data = { version = "0.5.2", path = "../../crates/data" }
 
 [[bin]]
 name = "showcase"

--- a/examples/rust/showcase.rs
+++ b/examples/rust/showcase.rs
@@ -217,6 +217,109 @@ fn show_inference_and_optimized_runtime() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+fn show_oblique_and_builder_strategies() -> Result<(), Box<dyn Error>> {
+    let x = vec![
+        vec![-2.0, 1.0],
+        vec![1.0, -2.0],
+        vec![-1.0, 2.0],
+        vec![2.0, -1.0],
+        vec![-3.0, 1.0],
+        vec![1.0, -3.0],
+        vec![-1.0, 3.0],
+        vec![3.0, -1.0],
+    ];
+    let y = vec![0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0];
+    let table = Table::with_options(x.clone(), y, 0, NumericBins::Fixed(64))?;
+
+    let axis = train(
+        &table,
+        TrainConfig {
+            algorithm: TrainAlgorithm::Dt,
+            task: Task::Classification,
+            tree_type: TreeType::Cart,
+            split_strategy: SplitStrategy::AxisAligned,
+            builder: BuilderStrategy::Greedy,
+            lookahead_depth: 1,
+            lookahead_top_k: 8,
+            lookahead_weight: 1.0,
+            beam_width: 4,
+            criterion: Criterion::Gini,
+            ..TrainConfig::default()
+        },
+    )?;
+    let oblique_beam = train(
+        &table,
+        TrainConfig {
+            algorithm: TrainAlgorithm::Dt,
+            task: Task::Classification,
+            tree_type: TreeType::Cart,
+            split_strategy: SplitStrategy::Oblique,
+            builder: BuilderStrategy::Beam,
+            lookahead_depth: 2,
+            lookahead_top_k: 4,
+            lookahead_weight: 0.5,
+            beam_width: 2,
+            criterion: Criterion::Gini,
+            canary_filter: CanaryFilter::TopFraction(0.95),
+            ..TrainConfig::default()
+        },
+    )?;
+
+    print_section("Oblique And Builder Strategies");
+    println!("axis used     -> {:?}", axis.used_feature_indices());
+    println!("oblique used  -> {:?}", oblique_beam.used_feature_indices());
+    println!("axis pred     -> {:?}", axis.predict_rows(x[..4].to_vec())?);
+    println!(
+        "oblique pred  -> {:?}",
+        oblique_beam.predict_rows(x[..4].to_vec())?
+    );
+    Ok(())
+}
+
+fn show_missing_value_routing() -> Result<(), Box<dyn Error>> {
+    let x = vec![
+        vec![0.0, f64::NAN, 1.0],
+        vec![0.0, 0.0, 1.0],
+        vec![1.0, f64::NAN, 0.0],
+        vec![1.0, 1.0, 0.0],
+        vec![0.0, 1.0, 1.0],
+        vec![1.0, 0.0, 0.0],
+    ];
+    let y = vec![0.0, 0.0, 1.0, 1.0, 0.0, 1.0];
+    let table = Table::with_options(x.clone(), y, 0, NumericBins::Auto)?;
+
+    let heuristic = train(
+        &table,
+        TrainConfig {
+            algorithm: TrainAlgorithm::Dt,
+            task: Task::Classification,
+            tree_type: TreeType::Cart,
+            split_strategy: SplitStrategy::AxisAligned,
+            builder: BuilderStrategy::Greedy,
+            lookahead_depth: 1,
+            lookahead_top_k: 8,
+            lookahead_weight: 1.0,
+            beam_width: 4,
+            criterion: Criterion::Gini,
+            missing_value_strategy: MissingValueStrategyConfig::heuristic(),
+            ..TrainConfig::default()
+        },
+    )?;
+
+    let optimized = heuristic.optimize_inference_with_missing_features(Some(1), Some(vec![1]))?;
+
+    print_section("Missing Value Routing");
+    println!(
+        "base pred     -> {:?}",
+        heuristic.predict_rows(x[..4].to_vec())?
+    );
+    println!(
+        "optimized pred-> {:?}",
+        optimized.predict_rows(x[..4].to_vec())?
+    );
+    Ok(())
+}
+
 fn show_serialization() -> Result<(), Box<dyn Error>> {
     let (x, y) = regression_rows();
     let table = Table::with_options(x.clone(), y, 0, NumericBins::Auto)?;
@@ -269,6 +372,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     show_classification_models()?;
     show_tables()?;
     show_inference_and_optimized_runtime()?;
+    show_oblique_and_builder_strategies()?;
+    show_missing_value_routing()?;
     show_serialization()?;
     Ok(())
 }

--- a/examples/rust/showcase.rs
+++ b/examples/rust/showcase.rs
@@ -55,6 +55,7 @@ fn show_regression_models() -> Result<(), Box<dyn Error>> {
                 lookahead_depth: 1,
                 lookahead_top_k: 8,
                 lookahead_weight: 1.0,
+                beam_width: 4,
                 criterion,
                 max_depth: None,
 
@@ -105,6 +106,7 @@ fn show_classification_models() -> Result<(), Box<dyn Error>> {
                 lookahead_depth: 1,
                 lookahead_top_k: 8,
                 lookahead_weight: 1.0,
+                beam_width: 4,
                 criterion,
                 max_depth: None,
 
@@ -160,6 +162,7 @@ fn show_inference_and_optimized_runtime() -> Result<(), Box<dyn Error>> {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Gini,
             max_depth: None,
 
@@ -228,6 +231,7 @@ fn show_serialization() -> Result<(), Box<dyn Error>> {
             lookahead_depth: 1,
             lookahead_top_k: 8,
             lookahead_weight: 1.0,
+            beam_width: 4,
             criterion: Criterion::Mean,
             max_depth: None,
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,9 @@ nav:
   - Rust API: rust-api.md
   - Examples: examples.md
   - Training: training.md
+  - Builders:
+      - Lookahead Builder: lookahead-builder.md
+      - Beam Builder: beam-builder.md
   - Categorical Strategies: categorical-strategies.md
   - Oblique Splits: oblique-splits.md
   - Models And Introspection: models.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "forestfire-workspace"
-version = "0.5.1"
+version = "0.5.2"
 requires-python = ">=3.12"
 
 [tool.uv.workspace]

--- a/uv.lock
+++ b/uv.lock
@@ -420,7 +420,7 @@ wheels = [
 
 [[package]]
 name = "forestfire-ml"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "bindings/python" }
 dependencies = [
     { name = "numpy" },
@@ -462,7 +462,7 @@ dev = [
 
 [[package]]
 name = "forestfire-workspace"
-version = "0.5.1"
+version = "0.5.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

This PR adds builder-aware tree construction to the training stack and brings the docs up to date with the newer public features that had accumulated around oblique splits, categorical handling, missing-value controls, and non-greedy builders.

The main implementation change is a new `builder` parameter with three modes:

- `greedy`
- `lookahead`
- `beam`

`greedy` preserves the existing immediate-gain behavior. `lookahead` re-ranks the top immediate split candidates using future score from a bounded continuation search. `beam` extends that by keeping multiple strong continuations alive during rescoring via `beam_width`.

The documentation side of the PR restructures the old lookahead material into a dedicated `Builders` docs section, adds a matching beam-builder page, and expands the examples so the newer public API surface is actually represented with runnable snippets.

## Builder changes

The training API now exposes:

- `builder`
- `lookahead_depth`
- `lookahead_top_k`
- `lookahead_weight`
- `beam_width`

These are wired through:

- Rust `TrainConfig`
- unified training dispatch
- decision trees
- random forests
- GBM
- Python `train(...)`
- sklearn-style wrappers

Behavior:

- `builder="greedy"` ranks by immediate gain only
- `builder="lookahead"` shortlists the top `lookahead_top_k` immediate candidates and re-scores them with:
  - `immediate_gain + lookahead_weight * future_gain`
  - following only the single best continuation
- `builder="beam"` uses the same rescoring framework, but keeps the top `beam_width` future continuations alive at each step before taking the strongest resulting continuation score

This currently applies across the exposed tree families, subject to the existing split-family constraints. In particular, oblique support still follows the existing `cart` / `randomized` support matrix.

One implementation detail worth calling out: the current beam builder is a pragmatic width-limited continuation search layered onto the existing local split-ranking path. It is not yet a full global beam search over whole partial-tree states.

## Documentation

Docs are updated to reflect the current public API and feature set.

### New builder docs

Added a dedicated builders section in the docs nav with:

- [docs/lookahead-builder.md](forest-fire/docs/lookahead-builder.md)
- [docs/beam-builder.md](forest-fire/docs/beam-builder.md)

These pages document:

- public parameters
- ranking behavior
- missing-value interaction
- support matrix
- tradeoffs and recommended starting settings

### Updated API/training docs

Updated:

- [docs/python-api.md](forest-fire/docs/python-api.md)
- [docs/rust-api.md](forest-fire/docs/rust-api.md)
- [docs/training.md](forest-fire/docs/training.md)
- [docs/index.md](forest-fire/docs/index.md)
- [mkdocs.yml](forest-fire/mkdocs.yml)

These now describe the builder surface explicitly instead of only documenting tree type and split strategy.

### Expanded examples

Updated [docs/examples.md](/Users/waltersperat/Desktop/Personal/forest-fire/docs/examples.md) with additional runnable examples for:

- missing-value routing and optimized runtime missing checks
- native categorical strategies: `dummy`, `target`, `fisher`
- `greedy` vs `lookahead` vs `beam`
- oblique splits combined with beam search

That closes the gap between the actual current code and the examples shown in the docs.

## Testing

Verified with:

- `cargo fmt --all`
- `cargo clippy -p forestfire-core -p forestfire-python --all-targets --all-features -- -D warnings`
- `uv run maturin develop -m bindings/python/Cargo.toml`
- direct Python smoke for `builder="beam"` across `dt`, `rf`, and `gbm`
- `task docs-build`

## Notes

This PR is partly feature work and partly documentation debt payoff.

The code side makes builder strategy a first-class training concept instead of overloading lookahead behavior into a single parameter path. The docs side brings the published examples and reference pages back in sync with the current implementation, especially for features that were already shipped but not yet represented well in the public documentation.